### PR TITLE
feat: add SAP integration orchestration and UI status

### DIFF
--- a/mdm-platform/README.md
+++ b/mdm-platform/README.md
@@ -16,4 +16,4 @@ Monorepo com **Next.js (web)** + **NestJS (api)** + **PostgreSQL** + **Docker co
 3. `pnpm --filter @mdm/api run migration:run`
 4. `pnpm dev` (roda web e api via turbo)
 
-- Configure o SAP com `SAP_BASE_URL`, `SAP_USER`, `SAP_PASSWORD` e opcionalmente `SAP_SYNC_ENABLED=false` para desativar o job de sincronização.
+- Configure o SAP com `SAP_BASE_URL`, `SAP_USER`, `SAP_PASSWORD`, `SAP_REQUEST_TIMEOUT` (opcional, em ms) e opcionalmente `SAP_SYNC_ENABLED=false` para desativar o envio automático.

--- a/mdm-platform/apps/api/src/modules/partners/__tests__/document-validation.spec.ts
+++ b/mdm-platform/apps/api/src/modules/partners/__tests__/document-validation.spec.ts
@@ -84,13 +84,25 @@ describe("PartnersService lookup", () => {
   const changeRepo = { find: vi.fn(), save: vi.fn() };
   const auditJobRepo = { findOne: vi.fn(), update: vi.fn() };
   const auditLogRepo = { save: vi.fn() };
+  const sapIntegration = {
+    integratePartner: vi.fn().mockResolvedValue({ segments: [], completed: true, updates: {} }),
+    retry: vi.fn().mockResolvedValue({ segments: [], completed: true, updates: {} })
+  };
 
   let service: PartnersService;
 
   beforeEach(() => {
     vi.restoreAllMocks();
     repo.findOne.mockReset();
-    service = new PartnersService(repo as any, changeRepo as any, auditJobRepo as any, auditLogRepo as any);
+    sapIntegration.integratePartner.mockReset();
+    sapIntegration.retry.mockReset();
+    service = new PartnersService(
+      repo as any,
+      changeRepo as any,
+      auditJobRepo as any,
+      auditLogRepo as any,
+      sapIntegration as any
+    );
   });
 
   it("rejects invalid CPF", async () => {

--- a/mdm-platform/apps/api/src/modules/partners/__tests__/sap-integration.service.spec.ts
+++ b/mdm-platform/apps/api/src/modules/partners/__tests__/sap-integration.service.spec.ts
@@ -1,0 +1,169 @@
+import "reflect-metadata";
+import { afterAll, afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SapIntegrationService } from "../sap-integration.service";
+import { Partner } from "../entities/partner.entity";
+
+const originalEnv = {
+  SAP_SYNC_ENABLED: process.env.SAP_SYNC_ENABLED,
+  SAP_BASE_URL: process.env.SAP_BASE_URL,
+  SAP_USER: process.env.SAP_USER,
+  SAP_PASSWORD: process.env.SAP_PASSWORD,
+  SAP_REQUEST_TIMEOUT: process.env.SAP_REQUEST_TIMEOUT
+};
+
+const createPartner = (overrides: Partial<Partner> = {}): Partner =>
+  ({
+    id: "partner-1",
+    mdmPartnerId: 1000,
+    sapBusinessPartnerId: overrides.sapBusinessPartnerId ?? null,
+    documento: "12345678901234",
+    nome_legal: "Empresa Teste",
+    nome_fantasia: "Empresa",
+    tipo_pessoa: "PJ",
+    natureza: "cliente",
+    contato_principal: { nome: "Fulano", email: "fulano@example.com" },
+    fiscal_info: {},
+    addresses: [],
+    banks: [],
+    transportadores: [],
+    sap_segments: [],
+    ...overrides
+  } as Partner);
+
+const mockFetchResponse = (body: any, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  text: async () => {
+    if (body === undefined || body === null) return "";
+    return typeof body === "string" ? body : JSON.stringify(body);
+  }
+});
+
+beforeEach(() => {
+  process.env.SAP_SYNC_ENABLED = "true";
+  delete process.env.SAP_BASE_URL;
+  delete process.env.SAP_USER;
+  delete process.env.SAP_PASSWORD;
+  delete process.env.SAP_REQUEST_TIMEOUT;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+afterAll(() => {
+  Object.entries(originalEnv).forEach(([key, value]) => {
+    if (value === undefined) {
+      delete (process.env as any)[key];
+    } else {
+      process.env[key] = value as string;
+    }
+  });
+});
+
+describe("SapIntegrationService", () => {
+  it("marks segments as success when integration is disabled", async () => {
+    process.env.SAP_SYNC_ENABLED = "false";
+    const service = new SapIntegrationService();
+    const onStateChange = vi.fn();
+    const partner = createPartner();
+
+    const result = await service.integratePartner(partner, { onStateChange });
+
+    expect(result.completed).toBe(true);
+    expect(result.segments).toHaveLength(4);
+    expect(result.segments.every((segment) => segment.status === "success")).toBe(true);
+    expect(onStateChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("marks segments as error when SAP is not configured", async () => {
+    const service = new SapIntegrationService();
+    const partner = createPartner();
+
+    const result = await service.integratePartner(partner);
+
+    expect(result.completed).toBe(false);
+    expect(result.segments.every((segment) => segment.status === "error")).toBe(true);
+  });
+
+  it("sends requests sequentially and captures SAP id", async () => {
+    process.env.SAP_BASE_URL = "https://sap.example";
+    process.env.SAP_USER = "user";
+    process.env.SAP_PASSWORD = "secret";
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(mockFetchResponse({ businessPartnerId: "BP100" }))
+      .mockResolvedValueOnce(mockFetchResponse({}))
+      .mockResolvedValueOnce(mockFetchResponse({}))
+      .mockResolvedValueOnce(mockFetchResponse({}));
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const service = new SapIntegrationService();
+    const partner = createPartner();
+    const onStateChange = vi.fn();
+
+    const result = await service.integratePartner(partner, { onStateChange });
+
+    expect(fetchMock).toHaveBeenCalledTimes(4);
+    expect(fetchMock).toHaveBeenNthCalledWith(
+      1,
+      "https://sap.example/business-partners",
+      expect.objectContaining({ method: "POST" })
+    );
+    expect(result.completed).toBe(true);
+    const firstSegment = result.segments.find((segment) => segment.segment === "businessPartner");
+    expect(firstSegment?.status).toBe("success");
+    expect(firstSegment?.sapId).toBe("BP100");
+    expect(result.updates.sapBusinessPartnerId).toBe("BP100");
+    expect(onStateChange).toHaveBeenCalled();
+  });
+
+  it("stops integration on first failure", async () => {
+    process.env.SAP_BASE_URL = "https://sap.example";
+    process.env.SAP_USER = "user";
+    process.env.SAP_PASSWORD = "secret";
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce(mockFetchResponse({ businessPartnerId: "BP100" }))
+      .mockResolvedValueOnce({ ok: false, status: 500, text: async () => JSON.stringify({ message: "Erro" }) });
+
+    vi.stubGlobal("fetch", fetchMock);
+
+    const service = new SapIntegrationService();
+    const partner = createPartner();
+    const onStateChange = vi.fn();
+
+    const result = await service.integratePartner(partner, { onStateChange });
+
+    expect(result.completed).toBe(false);
+    const statuses = result.segments.reduce<Record<string, string>>((acc, segment) => {
+      acc[segment.segment] = segment.status;
+      return acc;
+    }, {});
+    expect(statuses.businessPartner).toBe("success");
+    expect(statuses.addresses).toBe("error");
+    expect(statuses.roles).toBe("pending");
+    expect(statuses.banks).toBe("pending");
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(onStateChange).toHaveBeenCalledTimes(4);
+  });
+
+  it("skips retry when there are no pending segments", async () => {
+    const service = new SapIntegrationService();
+    const partner = createPartner({
+      sap_segments: [
+        { segment: "businessPartner", status: "success" },
+        { segment: "addresses", status: "success" },
+        { segment: "roles", status: "success" },
+        { segment: "banks", status: "success" }
+      ] as any
+    });
+
+    const result = await service.retry(partner);
+
+    expect(result.completed).toBe(true);
+    expect(result.segments.every((segment) => segment.status === "success")).toBe(true);
+  });
+});

--- a/mdm-platform/apps/api/src/modules/partners/dto/create-partner.dto.ts
+++ b/mdm-platform/apps/api/src/modules/partners/dto/create-partner.dto.ts
@@ -13,6 +13,7 @@ import {
   ValidatorConstraint,
   ValidatorConstraintInterface
 } from "class-validator";
+import { SapIntegrationSegmentState } from "@mdm/types";
 import { onlyDigits, validateCNPJ, validateCPF } from "@mdm/utils";
 import { IsCep, IsIbgeCode, IsStateRegistration } from "../../../common/validators";
 
@@ -239,7 +240,7 @@ export class CreatePartnerDto {
 
   @ApiProperty({ type: Array, required: false })
   @IsOptional()
-  sap_segments?: any[];
+  sap_segments?: SapIntegrationSegmentState[];
 
   @ApiProperty({ required: false })
   @IsOptional()

--- a/mdm-platform/apps/api/src/modules/partners/entities/partner.entity.ts
+++ b/mdm-platform/apps/api/src/modules/partners/entities/partner.entity.ts
@@ -1,5 +1,5 @@
 import { Column, CreateDateColumn, Entity, Generated, OneToMany, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
-import { PartnerApprovalHistoryEntry, PartnerApprovalStage } from "@mdm/types";
+import { PartnerApprovalHistoryEntry, PartnerApprovalStage, SapIntegrationSegmentState } from "@mdm/types";
 import { PartnerAuditLog } from "./partner-audit-log.entity";
 import { PartnerChangeRequest } from "./partner-change-request.entity";
 
@@ -92,7 +92,7 @@ export class Partner {
   };
 
   @Column("jsonb", { default: [] })
-  sap_segments!: any[];
+  sap_segments!: SapIntegrationSegmentState[];
 
   @Column({ name: "approval_stage", default: "fiscal" })
   approvalStage!: PartnerApprovalStage;

--- a/mdm-platform/apps/api/src/modules/partners/partners.controller.ts
+++ b/mdm-platform/apps/api/src/modules/partners/partners.controller.ts
@@ -130,5 +130,10 @@ export class PartnersController {
   rejectDadosMestres(@Param("id") id: string, @Req() req: AuthenticatedRequest, @Body() body: StageDecisionDto) {
     return this.svc.rejectStage(id, "dados_mestres", req.user, body?.motivo);
   }
+
+  @Post(":id/integrations/sap/retry")
+  retrySapIntegration(@Param("id") id: string) {
+    return this.svc.retrySapIntegration(id);
+  }
 }
 

--- a/mdm-platform/apps/api/src/modules/partners/partners.module.ts
+++ b/mdm-platform/apps/api/src/modules/partners/partners.module.ts
@@ -7,13 +7,14 @@ import { PartnerAuditLog } from './entities/partner-audit-log.entity';
 import { PartnersService } from './partners.service';
 import { PartnersController } from './partners.controller';
 import { AuthModule } from '../auth/auth.module';
+import { SapIntegrationService } from './sap-integration.service';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Partner, PartnerChangeRequest, PartnerAuditJob, PartnerAuditLog]),
     AuthModule,
   ],
-  providers: [PartnersService],
+  providers: [PartnersService, SapIntegrationService],
   controllers: [PartnersController],
 })
 export class PartnersModule {}

--- a/mdm-platform/apps/api/src/modules/partners/partners.service.ts
+++ b/mdm-platform/apps/api/src/modules/partners/partners.service.ts
@@ -19,6 +19,7 @@ import { Partner } from "./entities/partner.entity";
 import { PartnerAuditJob } from "./entities/partner-audit-job.entity";
 import { PartnerAuditLog } from "./entities/partner-audit-log.entity";
 import { PartnerChangeRequest } from "./entities/partner-change-request.entity";
+import { SapIntegrationService } from "./sap-integration.service";
 import {
   changeRequestFieldDefinitions,
   ChangeRequestOrigin,
@@ -54,7 +55,8 @@ export class PartnersService {
     @InjectRepository(Partner) private readonly repo: Repository<Partner>,
     @InjectRepository(PartnerChangeRequest) private readonly changeRepo: Repository<PartnerChangeRequest>,
     @InjectRepository(PartnerAuditJob) private readonly auditJobRepo: Repository<PartnerAuditJob>,
-    @InjectRepository(PartnerAuditLog) private readonly auditLogRepo: Repository<PartnerAuditLog>
+    @InjectRepository(PartnerAuditLog) private readonly auditLogRepo: Repository<PartnerAuditLog>,
+    private readonly sapIntegration: SapIntegrationService
   ) {}
 
   private getNextStage(current: PartnerApprovalStage): PartnerApprovalStage | null {
@@ -374,12 +376,64 @@ export class PartnersService {
     if (!nextStage || nextStage === FINAL_STAGE) {
       partner.approvalStage = FINAL_STAGE;
       partner.status = "aprovado";
-    } else {
-      partner.approvalStage = nextStage;
-      partner.status = "em_validacao";
+      await this.repo.save(partner);
+      return this.approve(partner.id);
     }
 
+    partner.approvalStage = nextStage;
+    partner.status = "em_validacao";
+
     return this.repo.save(partner);
+  }
+
+  async approve(id: string) {
+    const partner = await this.findOne(id);
+    if (partner.approvalStage !== FINAL_STAGE) {
+      throw new BadRequestException("Parceiro não está na etapa final para aprovação");
+    }
+
+    const result = await this.sapIntegration.integratePartner(partner, {
+      onStateChange: async (segments) => {
+        partner.sap_segments = segments;
+        await this.repo.update(partner.id, { sap_segments: segments });
+      }
+    });
+
+    partner.sap_segments = result.segments;
+    Object.entries(result.updates).forEach(([key, value]) => {
+      if (value !== undefined) {
+        (partner as any)[key] = value;
+      }
+    });
+
+    partner.status = result.completed ? "integrado" : "aprovado";
+    await this.repo.save(partner);
+    return partner;
+  }
+
+  async retrySapIntegration(id: string) {
+    const partner = await this.findOne(id);
+    if (partner.approvalStage !== FINAL_STAGE) {
+      throw new BadRequestException("Somente parceiros finalizados podem ser reenviados ao SAP");
+    }
+
+    const result = await this.sapIntegration.retry(partner, {
+      onStateChange: async (segments) => {
+        partner.sap_segments = segments;
+        await this.repo.update(partner.id, { sap_segments: segments });
+      }
+    });
+
+    partner.sap_segments = result.segments;
+    Object.entries(result.updates).forEach(([key, value]) => {
+      if (value !== undefined) {
+        (partner as any)[key] = value;
+      }
+    });
+
+    partner.status = result.completed ? "integrado" : "aprovado";
+    await this.repo.save(partner);
+    return partner;
   }
 
   async rejectStage(id: string, stage: PartnerApprovalStage, user: AuthenticatedUser, reason?: string) {

--- a/mdm-platform/apps/api/src/modules/partners/sap-integration.service.ts
+++ b/mdm-platform/apps/api/src/modules/partners/sap-integration.service.ts
@@ -1,0 +1,393 @@
+import { Injectable, Logger } from "@nestjs/common";
+import {
+  SapIntegrationSegment,
+  SapIntegrationSegmentState,
+  SapIntegrationStatus
+} from "@mdm/types";
+import { Partner } from "./entities/partner.entity";
+
+export type SapIntegrationResult = {
+  segments: SapIntegrationSegmentState[];
+  completed: boolean;
+  updates: Partial<Partner>;
+};
+
+export type SapIntegrationOptions = {
+  segments?: SapIntegrationSegment[];
+  onStateChange?: (segments: SapIntegrationSegmentState[]) => Promise<void> | void;
+};
+
+const DEFAULT_SEGMENTS: SapIntegrationSegment[] = [
+  "businessPartner",
+  "addresses",
+  "roles",
+  "banks"
+];
+
+type SegmentConfig = {
+  method: "POST" | "PUT";
+  path: string;
+  buildPayload: (partner: Partner) => any;
+  successMessage: string;
+};
+
+@Injectable()
+export class SapIntegrationService {
+  private readonly logger = new Logger(SapIntegrationService.name);
+
+  async integratePartner(partner: Partner, options: SapIntegrationOptions = {}): Promise<SapIntegrationResult> {
+    let states = this.prepareInitialState(partner.sap_segments);
+    const segments = this.normalizeSegments(options.segments, true);
+
+    if (!segments.length) {
+      return { segments: states, completed: true, updates: {} };
+    }
+
+    if (!this.isEnabled()) {
+      const now = new Date().toISOString();
+      states = states.map((state) =>
+        segments.includes(state.segment)
+          ? {
+              ...state,
+              status: "success",
+              lastAttemptAt: now,
+              lastSuccessAt: now,
+              message: "Integração SAP desativada (SAP_SYNC_ENABLED=false)",
+              errorMessage: undefined
+            }
+          : state
+      );
+      await this.notifyStateChange(options, states);
+      return { segments: states, completed: true, updates: {} };
+    }
+
+    if (!this.isConfigured()) {
+      const now = new Date().toISOString();
+      const message = "Configuração SAP incompleta. Defina SAP_BASE_URL, SAP_USER e SAP_PASSWORD.";
+      states = states.map((state) =>
+        segments.includes(state.segment)
+          ? {
+              ...state,
+              status: "error",
+              lastAttemptAt: now,
+              errorMessage: message
+            }
+          : state
+      );
+      await this.notifyStateChange(options, states);
+      return { segments: states, completed: false, updates: {} };
+    }
+
+    let completed = true;
+    const updates: Partial<Partner> = {};
+
+    for (const segment of segments) {
+      const attemptAt = new Date().toISOString();
+      states = this.upsertState(states, {
+        segment,
+        status: "processing",
+        lastAttemptAt: attemptAt,
+        errorMessage: undefined,
+        message: undefined
+      });
+      await this.notifyStateChange(options, states);
+
+      try {
+        const response = await this.dispatchSegment(segment, partner);
+        const segmentUpdates = this.extractPartnerUpdates(segment, response);
+        if (Object.keys(segmentUpdates).length) {
+          Object.assign(updates, segmentUpdates);
+        }
+
+        const sapId = this.extractSegmentIdentifier(segment, response, segmentUpdates);
+        const successState: SapIntegrationSegmentState = {
+          segment,
+          status: "success",
+          lastAttemptAt: attemptAt,
+          lastSuccessAt: new Date().toISOString(),
+          message: this.segmentConfig[segment].successMessage,
+          errorMessage: undefined,
+          sapId: sapId ?? undefined
+        };
+        states = this.upsertState(states, successState);
+        await this.notifyStateChange(options, states);
+      } catch (error) {
+        completed = false;
+        const message =
+          error instanceof Error ? error.message : "Falha desconhecida ao integrar com o SAP";
+        this.logger.error(
+          `Falha ao integrar parceiro ${partner.id} no segmento ${segment}: ${message}`,
+          error instanceof Error ? error.stack : undefined
+        );
+        states = this.upsertState(states, {
+          segment,
+          status: "error",
+          lastAttemptAt: attemptAt,
+          errorMessage: message
+        });
+        await this.notifyStateChange(options, states);
+        break;
+      }
+    }
+
+    return { segments: states, completed, updates };
+  }
+
+  async retry(partner: Partner, options: SapIntegrationOptions = {}): Promise<SapIntegrationResult> {
+    const states = this.prepareInitialState(partner.sap_segments);
+    const failed = states.filter((state) => state.status !== "success").map((state) => state.segment);
+    const targets = options.segments?.length ? options.segments : failed;
+    const segments = this.normalizeSegments(targets, false);
+    if (!segments.length) {
+      return { segments: states, completed: true, updates: {} };
+    }
+    return this.integratePartner(partner, { ...options, segments });
+  }
+
+  private normalizeSegments(
+    segments: SapIntegrationSegment[] | undefined,
+    fallbackToDefault: boolean
+  ): SapIntegrationSegment[] {
+    if (!segments) {
+      return fallbackToDefault ? [...DEFAULT_SEGMENTS] : [];
+    }
+    if (!segments.length) {
+      return fallbackToDefault ? [...DEFAULT_SEGMENTS] : [];
+    }
+    const allowed = new Set(DEFAULT_SEGMENTS);
+    return Array.from(new Set(segments.filter((segment) => allowed.has(segment))));
+  }
+
+  private prepareInitialState(existing: SapIntegrationSegmentState[] = []): SapIntegrationSegmentState[] {
+    const map = new Map(existing.map((state) => [state.segment, state]));
+    return DEFAULT_SEGMENTS.map((segment) => {
+      const current = map.get(segment);
+      return current
+        ? { ...current, segment: current.segment }
+        : { segment, status: "pending" as SapIntegrationStatus };
+    });
+  }
+
+  private upsertState(
+    states: SapIntegrationSegmentState[],
+    next: SapIntegrationSegmentState
+  ): SapIntegrationSegmentState[] {
+    const exists = states.some((state) => state.segment === next.segment);
+    if (!exists) {
+      return [...states, next];
+    }
+    return states.map((state) => (state.segment === next.segment ? { ...state, ...next } : state));
+  }
+
+  private async notifyStateChange(
+    options: SapIntegrationOptions,
+    states: SapIntegrationSegmentState[]
+  ) {
+    if (!options.onStateChange) return;
+    const snapshot = states.map((state) => ({ ...state }));
+    await options.onStateChange(snapshot);
+  }
+
+  private get isEnabled(): boolean {
+    return process.env.SAP_SYNC_ENABLED !== "false";
+  }
+
+  private get isConfigured(): boolean {
+    return Boolean(this.baseUrl && this.user && this.password);
+  }
+
+  private get baseUrl(): string {
+    return (process.env.SAP_BASE_URL || "").replace(/\/$/, "");
+  }
+
+  private get user(): string {
+    return process.env.SAP_USER || "";
+  }
+
+  private get password(): string {
+    return process.env.SAP_PASSWORD || "";
+  }
+
+  private get timeout(): number {
+    const raw = process.env.SAP_REQUEST_TIMEOUT;
+    const parsed = raw ? Number(raw) : NaN;
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 15000;
+  }
+
+  private get authorizationHeader(): string | null {
+    if (!this.user && !this.password) return null;
+    const token = Buffer.from(`${this.user}:${this.password}`).toString("base64");
+    return `Basic ${token}`;
+  }
+
+  private segmentConfig: Record<SapIntegrationSegment, SegmentConfig> = {
+    businessPartner: {
+      method: "POST",
+      path: "/business-partners",
+      successMessage: "Parceiro principal sincronizado",
+      buildPayload: (partner) => ({
+        mdmPartnerId: partner.mdmPartnerId,
+        partnerId: partner.id,
+        document: partner.documento,
+        name: partner.nome_legal,
+        tradeName: partner.nome_fantasia,
+        type: partner.tipo_pessoa,
+        nature: partner.natureza,
+        contact: partner.contato_principal,
+        fiscal: partner.fiscal_info
+      })
+    },
+    addresses: {
+      method: "PUT",
+      path: "/business-partners/addresses",
+      successMessage: "Endereços sincronizados",
+      buildPayload: (partner) => ({
+        businessPartnerId: partner.sapBusinessPartnerId ?? null,
+        mdmPartnerId: partner.mdmPartnerId,
+        partnerId: partner.id,
+        document: partner.documento,
+        addresses: partner.addresses
+      })
+    },
+    roles: {
+      method: "PUT",
+      path: "/business-partners/roles",
+      successMessage: "Funções sincronizadas",
+      buildPayload: (partner) => ({
+        businessPartnerId: partner.sapBusinessPartnerId ?? null,
+        mdmPartnerId: partner.mdmPartnerId,
+        partnerId: partner.id,
+        document: partner.documento,
+        roles: this.buildRoles(partner)
+      })
+    },
+    banks: {
+      method: "PUT",
+      path: "/business-partners/banks",
+      successMessage: "Bancos sincronizados",
+      buildPayload: (partner) => ({
+        businessPartnerId: partner.sapBusinessPartnerId ?? null,
+        mdmPartnerId: partner.mdmPartnerId,
+        partnerId: partner.id,
+        document: partner.documento,
+        banks: partner.banks
+      })
+    }
+  };
+
+  private buildRoles(partner: Partner): string[] {
+    const roles: string[] = [];
+    if (partner.natureza === "cliente" || partner.natureza === "ambos") {
+      roles.push("CUSTOMER");
+    }
+    if (partner.natureza === "fornecedor" || partner.natureza === "ambos") {
+      roles.push("VENDOR");
+    }
+    if (partner.transportadores?.length) {
+      roles.push("TRANSPORTER");
+    }
+    return roles;
+  }
+
+  private async dispatchSegment(segment: SapIntegrationSegment, partner: Partner) {
+    const config = this.segmentConfig[segment];
+    if (!config) {
+      throw new Error(`Segmento SAP desconhecido: ${segment}`);
+    }
+    const payload = config.buildPayload(partner);
+    return this.callSap(config.method, config.path, payload);
+  }
+
+  private extractPartnerUpdates(segment: SapIntegrationSegment, response: any): Partial<Partner> {
+    if (segment === "businessPartner") {
+      const sapId = this.extractBusinessPartnerId(response);
+      if (sapId) {
+        return { sapBusinessPartnerId: sapId } as Partial<Partner>;
+      }
+    }
+    return {};
+  }
+
+  private extractSegmentIdentifier(
+    segment: SapIntegrationSegment,
+    response: any,
+    updates: Partial<Partner>
+  ): string | null {
+    if (segment === "businessPartner") {
+      return (
+        this.extractBusinessPartnerId(response) ||
+        (updates.sapBusinessPartnerId ? String(updates.sapBusinessPartnerId) : null)
+      );
+    }
+    return null;
+  }
+
+  private extractBusinessPartnerId(response: any): string | null {
+    if (!response) return null;
+    if (typeof response === "string" && response.trim()) {
+      return response.trim();
+    }
+    const candidate =
+      response?.businessPartnerId ??
+      response?.BusinessPartner ??
+      response?.bpId ??
+      response?.id ??
+      response?.sapId;
+    if (candidate === undefined || candidate === null) {
+      return null;
+    }
+    const value = String(candidate).trim();
+    return value.length ? value : null;
+  }
+
+  private async callSap(method: "POST" | "PUT", path: string, body: any) {
+    const url = `${this.baseUrl}${path.startsWith("/") ? path : `/${path}`}`;
+    const headers: Record<string, string> = { "Content-Type": "application/json" };
+    const auth = this.authorizationHeader;
+    if (auth) {
+      headers.Authorization = auth;
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout);
+
+    try {
+      const response = await fetch(url, {
+        method,
+        headers,
+        body: JSON.stringify(body ?? {}),
+        signal: controller.signal
+      });
+
+      const raw = await response.text();
+      let parsed: any = null;
+      if (raw) {
+        try {
+          parsed = JSON.parse(raw);
+        } catch {
+          parsed = raw;
+        }
+      }
+
+      if (!response.ok) {
+        const message =
+          typeof parsed === "string"
+            ? parsed
+            : parsed?.message ?? `SAP respondeu com status ${response.status}`;
+        throw new Error(message);
+      }
+
+      return parsed;
+    } catch (error: any) {
+      if (error?.name === "AbortError") {
+        throw new Error("Tempo limite excedido ao comunicar com o SAP");
+      }
+      if (error instanceof Error) {
+        throw error;
+      }
+      throw new Error(String(error));
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+}

--- a/mdm-platform/apps/web/src/app/(protected)/partners/[id]/page.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/partners/[id]/page.tsx
@@ -3,8 +3,9 @@ import { useEffect, useMemo, useState } from "react";
 import Link from "next/link";
 import { useParams, useRouter } from "next/navigation";
 import axios from "axios";
-import type { Partner, PartnerApprovalHistoryEntry, PartnerApprovalStage } from "@mdm/types";
+import type { Partner, PartnerApprovalHistoryEntry, PartnerApprovalStage, SapIntegrationSegmentState } from "@mdm/types";
 import { ChangeRequestPayload } from "@mdm/types";
+import { mapSapSegments, SAP_SEGMENT_LABELS, SAP_STATUS_LABELS, summarizeSapOverall, shouldAllowSapRetry, SapOverallTone } from "../sap-integration-helpers";
 import { getStoredUser, storeUser, StoredUser } from "../../../../lib/auth";
 
 type ChangeRequestItem = {
@@ -85,6 +86,20 @@ const stageStateStyles: Record<StageStatus["state"], string> = {
   rejected: "border-red-200 bg-red-50 text-red-700"
 };
 
+const sapSegmentStatusStyles: Record<SapIntegrationSegmentState["status"], string> = {
+  success: "border-emerald-200 bg-emerald-50 text-emerald-700",
+  error: "border-red-200 bg-red-50 text-red-700",
+  processing: "border-indigo-200 bg-indigo-50 text-indigo-700",
+  pending: "border-zinc-200 bg-white text-zinc-600"
+};
+
+const sapOverallToneStyles: Record<SapOverallTone, string> = {
+  success: "border-emerald-200 bg-emerald-50 text-emerald-700",
+  error: "border-red-200 bg-red-50 text-red-700",
+  processing: "border-indigo-200 bg-indigo-50 text-indigo-700",
+  pending: "border-zinc-200 bg-zinc-50 text-zinc-600"
+};
+
 const formatDateTime = (value?: string) => {
   if (!value) return "-";
   const date = new Date(value);
@@ -108,6 +123,9 @@ export default function PartnerDetailsPage() {
   const [actionLoading, setActionLoading] = useState(false);
   const [actionError, setActionError] = useState<string | null>(null);
   const [actionSuccess, setActionSuccess] = useState<string | null>(null);
+  const [sapActionLoading, setSapActionLoading] = useState(false);
+  const [sapActionError, setSapActionError] = useState<string | null>(null);
+  const [sapActionSuccess, setSapActionSuccess] = useState<string | null>(null);
 
   useEffect(() => {
     if (!partnerId) return;
@@ -174,6 +192,19 @@ export default function PartnerDetailsPage() {
   useEffect(() => {
     setCurrentUser(getStoredUser());
   }, []);
+
+  const sapSegments = useMemo<SapIntegrationSegmentState[]>(() => {
+    if (!partner) return [];
+    return mapSapSegments(partner.sap_segments ?? []);
+  }, [partner]);
+
+  const sapOverall = useMemo(() => summarizeSapOverall(sapSegments), [sapSegments]);
+
+  const canRetrySapIntegration = useMemo(() => {
+    if (!partner) return false;
+    if ((partner.approvalStage || "") !== "finalizado") return false;
+    return shouldAllowSapRetry(sapSegments);
+  }, [partner, sapSegments]);
 
   const selectedPartnerSummary = useMemo(() => {
     if (!partner) return [] as Array<{ label: string; value: string }>;
@@ -291,6 +322,41 @@ export default function PartnerDetailsPage() {
       setActionError(typeof message === "string" ? message : "Não foi possível enviar para validação.");
     } finally {
       setActionLoading(false);
+    }
+  };
+
+  const handleRetrySapIntegration = async () => {
+    if (!partnerId || !process.env.NEXT_PUBLIC_API_URL) return;
+    setSapActionLoading(true);
+    setSapActionError(null);
+    setSapActionSuccess(null);
+    try {
+      const token = localStorage.getItem("mdmToken");
+      if (!token) {
+        router.replace("/login");
+        return;
+      }
+      const response = await axios.post(
+        `${process.env.NEXT_PUBLIC_API_URL}/partners/${partnerId}/integrations/sap/retry`,
+        {},
+        { headers: { Authorization: `Bearer ${token}` } }
+      );
+      const updated = response.data?.partner ?? response.data;
+      if (updated) {
+        setPartner(updated);
+      }
+      setSapActionSuccess("Integração reenviada ao SAP.");
+    } catch (err: any) {
+      if (err?.response?.status === 401) {
+        localStorage.removeItem("mdmToken");
+        storeUser(null);
+        router.replace("/login");
+        return;
+      }
+      const message = err?.response?.data?.message;
+      setSapActionError(typeof message === "string" ? message : "Não foi possível reenviar ao SAP.");
+    } finally {
+      setSapActionLoading(false);
     }
   };
 
@@ -427,6 +493,9 @@ export default function PartnerDetailsPage() {
         <div className="flex flex-wrap gap-3 text-xs text-zinc-600">
           <span className="rounded-full bg-zinc-100 px-3 py-1">Natureza: {partner.natureza}</span>
           <span className="rounded-full bg-zinc-100 px-3 py-1">Status: {partner.status}</span>
+          <span className={`rounded-full border px-3 py-1 font-medium ${sapOverallToneStyles[sapOverall.tone]}`}>
+            SAP: {sapOverall.label}
+          </span>
           {partner.sapBusinessPartnerId && (
             <span className="rounded-full bg-emerald-100 px-3 py-1 text-emerald-700">SAP BP {partner.sapBusinessPartnerId}</span>
           )}
@@ -551,6 +620,77 @@ export default function PartnerDetailsPage() {
                 )}
               </div>
             </div>
+          </section>
+
+
+
+          <section className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
+            <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+              <div>
+                <h2 className="text-sm font-semibold uppercase tracking-wide text-zinc-500">Integração SAP</h2>
+                <p className="text-xs text-zinc-500">{sapOverall.description}</p>
+              </div>
+              <span className={`rounded-full border px-3 py-1 text-xs font-semibold ${sapOverallToneStyles[sapOverall.tone]}`}>
+                {sapOverall.label}
+              </span>
+            </div>
+            {sapActionError && (
+              <div className="mt-3 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">{sapActionError}</div>
+            )}
+            {sapActionSuccess && (
+              <div className="mt-3 rounded-lg border border-emerald-200 bg-emerald-50 px-3 py-2 text-sm text-emerald-700">
+                {sapActionSuccess}
+              </div>
+            )}
+            <div className="mt-4 grid gap-3 md:grid-cols-2">
+              {sapSegments.map((segment) => (
+                <div key={segment.segment} className="flex flex-col gap-2 rounded-xl border border-zinc-200 bg-zinc-50 p-4">
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-sm font-semibold text-zinc-800">
+                      {SAP_SEGMENT_LABELS[segment.segment as keyof typeof SAP_SEGMENT_LABELS] ?? segment.segment}
+                    </span>
+                    <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-medium ${sapSegmentStatusStyles[segment.status]}`}>
+                      {SAP_STATUS_LABELS[segment.status] ?? segment.status}
+                    </span>
+                  </div>
+                  <dl className="space-y-1 text-xs text-zinc-600">
+                    <div className="flex items-center justify-between gap-2">
+                      <dt className="font-medium text-zinc-500">Última tentativa</dt>
+                      <dd>{segment.lastAttemptAt ? formatDateTime(segment.lastAttemptAt) : "-"}</dd>
+                    </div>
+                    {segment.lastSuccessAt && (
+                      <div className="flex items-center justify-between gap-2">
+                        <dt className="font-medium text-zinc-500">Último sucesso</dt>
+                        <dd>{formatDateTime(segment.lastSuccessAt)}</dd>
+                      </div>
+                    )}
+                  </dl>
+                  {segment.sapId && (
+                    <p className="text-xs text-zinc-500">
+                      SAP ID: <span className="font-medium text-zinc-700">{segment.sapId}</span>
+                    </p>
+                  )}
+                  {segment.errorMessage ? (
+                    <p className="text-xs text-red-600">{segment.errorMessage}</p>
+                  ) : segment.message ? (
+                    <p className="text-xs text-zinc-600">{segment.message}</p>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+            {canRetrySapIntegration && (
+              <div className="mt-4 flex flex-wrap items-center gap-3">
+                <button
+                  type="button"
+                  onClick={handleRetrySapIntegration}
+                  disabled={sapActionLoading}
+                  className="rounded-lg border border-indigo-200 bg-indigo-50 px-4 py-2 text-sm font-semibold text-indigo-700 transition-opacity disabled:opacity-60"
+                >
+                  {sapActionLoading ? "Reprocessando..." : "Reprocessar integração"}
+                </button>
+                <p className="text-xs text-zinc-500">Tente novamente após ajustar eventuais pendências.</p>
+              </div>
+            )}
           </section>
 
           <section className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">

--- a/mdm-platform/apps/web/src/app/(protected)/partners/sap-integration-helpers.ts
+++ b/mdm-platform/apps/web/src/app/(protected)/partners/sap-integration-helpers.ts
@@ -1,0 +1,110 @@
+import type { SapIntegrationSegmentState, SapIntegrationStatus } from "@mdm/types";
+
+export type SapOverallTone = "success" | "error" | "processing" | "pending";
+
+export const SAP_SEGMENT_ORDER: SapIntegrationSegmentState["segment"][] = [
+  "businessPartner",
+  "addresses",
+  "roles",
+  "banks"
+];
+
+export const SAP_SEGMENT_LABELS: Record<SapIntegrationSegmentState["segment"], string> = {
+  businessPartner: "Dados principais",
+  addresses: "Endereços",
+  roles: "Funções",
+  banks: "Bancos"
+};
+
+export const SAP_STATUS_LABELS: Record<SapIntegrationStatus, string> = {
+  pending: "Pendente",
+  processing: "Processando",
+  success: "Sucesso",
+  error: "Erro"
+};
+
+export type SapOverallStatus = {
+  label: string;
+  tone: SapOverallTone;
+  description: string;
+  disabled: boolean;
+};
+
+export function mapSapSegments(raw: any): SapIntegrationSegmentState[] {
+  const map = new Map<SapIntegrationSegmentState["segment"], SapIntegrationSegmentState>();
+  if (Array.isArray(raw)) {
+    raw.forEach((item) => {
+      if (!item || typeof item !== "object") return;
+      const segment = item.segment as SapIntegrationSegmentState["segment"] | undefined;
+      if (!segment) return;
+      map.set(segment, { ...item, segment } as SapIntegrationSegmentState);
+    });
+  }
+
+  const ordered = SAP_SEGMENT_ORDER.map((segment) => {
+    const current = map.get(segment);
+    return current ? { ...current, segment } : ({ segment, status: "pending" } as SapIntegrationSegmentState);
+  });
+
+  const extras = Array.isArray(raw)
+    ? raw.filter((item) => item?.segment && !SAP_SEGMENT_ORDER.includes(item.segment))
+    : [];
+
+  return [...ordered, ...extras] as SapIntegrationSegmentState[];
+}
+
+export function summarizeSapOverall(segments: SapIntegrationSegmentState[]): SapOverallStatus {
+  if (!segments.length || segments.every((segment) => segment.status === "pending")) {
+    return {
+      label: "Pendente",
+      tone: "pending",
+      description: "Aguardando processamento no SAP.",
+      disabled: false
+    };
+  }
+
+  if (segments.some((segment) => segment.status === "error")) {
+    return {
+      label: "Erro na integração",
+      tone: "error",
+      description: "Existe ao menos um segmento com falha. Reprocessar para tentar novamente.",
+      disabled: false
+    };
+  }
+
+  if (segments.some((segment) => segment.status === "processing")) {
+    return {
+      label: "Processando",
+      tone: "processing",
+      description: "Integração em andamento. Aguarde a conclusão.",
+      disabled: false
+    };
+  }
+
+  const allSuccess = segments.every((segment) => segment.status === "success");
+  if (allSuccess) {
+    const disabled = segments.every((segment) =>
+      (segment.message ?? "").toLowerCase().includes("desativad")
+    );
+    return {
+      label: disabled ? "Integração desativada" : "Integrado ao SAP",
+      tone: disabled ? "pending" : "success",
+      description: disabled
+        ? "O envio automático ao SAP está desativado via configuração."
+        : "Todos os segmentos foram sincronizados com sucesso.",
+      disabled
+    };
+  }
+
+  return {
+    label: "Parcialmente integrado",
+    tone: "processing",
+    description: "Alguns segmentos ainda não foram sincronizados com o SAP.",
+    disabled: false
+  };
+}
+
+export function shouldAllowSapRetry(segments: SapIntegrationSegmentState[]): boolean {
+  if (!segments.length) return true;
+  return segments.some((segment) => segment.status !== "success");
+}

--- a/mdm-platform/packages/types/src/partner.ts
+++ b/mdm-platform/packages/types/src/partner.ts
@@ -4,6 +4,25 @@ export const PartnerApprovalStageSchema = z.enum(["fiscal", "compras", "dados_me
 
 export const PartnerApprovalActionSchema = z.enum(["submitted", "approved", "rejected"]);
 
+export const SapIntegrationSegmentSchema = z.enum([
+  "businessPartner",
+  "addresses",
+  "roles",
+  "banks"
+]);
+
+export const SapIntegrationStatusSchema = z.enum(["pending", "processing", "success", "error"]);
+
+export const SapIntegrationSegmentStateSchema = z.object({
+  segment: SapIntegrationSegmentSchema,
+  status: SapIntegrationStatusSchema,
+  lastAttemptAt: z.string().optional(),
+  lastSuccessAt: z.string().optional(),
+  message: z.string().optional(),
+  errorMessage: z.string().optional(),
+  sapId: z.string().optional()
+});
+
 export const PartnerApprovalHistoryEntrySchema = z.object({
   stage: PartnerApprovalStageSchema,
   action: PartnerApprovalActionSchema,
@@ -85,7 +104,7 @@ export const PartnerSchema = z.object({
     montante: z.number().optional(),
     validade: z.string().optional()
   }).default({}),
-  sap_segments: z.array(z.any()).default([]),
+  sap_segments: z.array(SapIntegrationSegmentStateSchema).default([]),
   approvalStage: PartnerApprovalStageSchema.default("fiscal"),
   approvalHistory: z.array(PartnerApprovalHistoryEntrySchema).default([])
 });
@@ -94,3 +113,6 @@ export type Partner = z.infer<typeof PartnerSchema>;
 export type PartnerApprovalStage = z.infer<typeof PartnerApprovalStageSchema>;
 export type PartnerApprovalHistoryEntry = z.infer<typeof PartnerApprovalHistoryEntrySchema>;
 export type PartnerApprovalAction = z.infer<typeof PartnerApprovalActionSchema>;
+export type SapIntegrationSegment = z.infer<typeof SapIntegrationSegmentSchema>;
+export type SapIntegrationStatus = z.infer<typeof SapIntegrationStatusSchema>;
+export type SapIntegrationSegmentState = z.infer<typeof SapIntegrationSegmentStateSchema>;


### PR DESCRIPTION
## Summary
- implement SapIntegrationService to orchestrate SAP segment calls, persist status metadata, and expose retry entry points in the backend
- trigger SAP integration during final approval, persist state on partners, and surface status/retry controls in the web UI
- document required SAP environment variables and add unit coverage for the new connector

## Testing
- `pnpm --filter @mdm/api test` *(fails: vitest binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df10dc743483258db5f0b5b59158bb