### PR TITLE
feat(api): add SAP sync service with cron job

### DIFF
--- a/mdm-platform/README.md
+++ b/mdm-platform/README.md
@@ -16,4 +16,14 @@ Monorepo com **Next.js (web)** + **NestJS (api)** + **PostgreSQL** + **Docker co
 3. `pnpm --filter @mdm/api run migration:run`
 4. `pnpm dev` (roda web e api via turbo)
 
-- Configure o SAP com `SAP_BASE_URL`, `SAP_USER`, `SAP_PASSWORD`, `SAP_REQUEST_TIMEOUT` (opcional, em ms) e opcionalmente `SAP_SYNC_ENABLED=false` para desativar o envio automático.
+- Configure o SAP com `SAP_BASE_URL`, `SAP_USER`, `SAP_PASSWORD`, `SAP_REQUEST_TIMEOUT` (opcional, em ms).
+
+### Sincronização automática com o SAP
+
+- A API expõe um `SapSyncService` que periodicamente consulta o endpoint `/business-partners` do SAP para buscar cadastros e atualizações. O job roda por padrão a cada hora (`@Cron` com `SAP_SYNC_CRON` opcional) e respeita `SAP_SYNC_ENABLED=false` caso seja necessário desligar a sincronização.
+- Campos retornados pelo SAP são mapeados para a entidade `Partner` (ex.: `sapBusinessPartnerId`, `sap_segments`, `addresses`, `banks`, contato, comunicação etc.) e qualquer alteração é salva com auditoria (`PartnerAuditLog`) indicando os diffs vindos do SAP.
+- Variáveis úteis:
+  - `SAP_SYNC_ENABLED` (default `true`): controla tanto a integração quanto o job de leitura.
+  - `SAP_SYNC_PAGE_SIZE` (default `50`): tamanho da página na paginação do SAP.
+  - `SAP_SYNC_UPDATED_AFTER`: filtro opcional enviado ao SAP (`updatedAfter`).
+  - `SAP_SYNC_CRON`: expressão cron opcional para customizar a frequência do job.

--- a/mdm-platform/apps/api/package.json
+++ b/mdm-platform/apps/api/package.json
@@ -37,6 +37,7 @@
     "@types/node": "^20.12.8",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitest": "^2.1.4"
   }
 }

--- a/mdm-platform/apps/api/src/modules/partners/__tests__/sap-sync.mapper.spec.ts
+++ b/mdm-platform/apps/api/src/modules/partners/__tests__/sap-sync.mapper.spec.ts
@@ -1,0 +1,69 @@
+import "reflect-metadata";
+import { describe, expect, it } from "vitest";
+import { mapSapPartnerPayload } from "../sap-sync.mapper";
+
+describe("mapSapPartnerPayload", () => {
+  it("maps core fields and sanitizes strings", () => {
+    const payload = {
+      sapBusinessPartnerId: "  BP-001  ",
+      legalName: "Empresa X",
+      tradeName: "X LTDA",
+      document: "12.345.678/0001-99",
+      personType: "PJ",
+      nature: "cliente",
+      status: "integrado",
+      contact: { name: "João", email: "joao@example.com", phone: "1199999" },
+      communication: {
+        phone: "1130000000",
+        emails: [
+          { address: "financeiro@example.com", default: true },
+          { address: null }
+        ]
+      },
+      vendor: { grupo: "A" },
+      sales: { vendedor: "123" },
+      fiscal: { natureza_operacao: "5102" },
+      credit: { modalidade: "30d" },
+      addresses: [{ cep: "01001000" }],
+      banks: [{ banco: "001" }],
+      transporters: [{ sap_bp: "T1" }]
+    };
+
+    const result = mapSapPartnerPayload(payload as any);
+
+    expect(result.sapBusinessPartnerId).toBe("BP-001");
+    expect(result.nome_legal).toBe("Empresa X");
+    expect(result.nome_fantasia).toBe("X LTDA");
+    expect(result.documento).toBe("12.345.678/0001-99");
+    expect(result.tipo_pessoa).toBe("PJ");
+    expect(result.natureza).toBe("cliente");
+    expect(result.status).toBe("integrado");
+    expect(result.contato_principal).toEqual({ nome: "João", email: "joao@example.com", fone: "1199999" });
+    expect(result.comunicacao).toEqual({ telefone: "1130000000", emails: [{ endereco: "financeiro@example.com", padrao: true }] });
+    expect(result.fornecedor_info).toEqual({ grupo: "A" });
+    expect(result.vendas_info).toEqual({ vendedor: "123" });
+    expect(result.fiscal_info).toEqual({ natureza_operacao: "5102" });
+    expect(result.credito_info).toEqual({ modalidade: "30d" });
+    expect(result.addresses).toEqual([{ cep: "01001000" }]);
+    expect(result.banks).toEqual([{ banco: "001" }]);
+    expect(result.transportadores).toEqual([{ sap_bp: "T1" }]);
+  });
+
+  it("normalizes segments removing invalid entries", () => {
+    const payload = {
+      sapSegments: [
+        { segment: "businessPartner", status: "success", sapId: "123" },
+        { segment: "invalid", status: "ok" },
+        { code: "banks", status: "error", message: "fail" }
+      ]
+    };
+
+    const result = mapSapPartnerPayload(payload as any);
+
+    expect(result.sap_segments).toEqual([
+      { segment: "banks", status: "error", message: "fail" },
+      { segment: "businessPartner", status: "success", sapId: "123" }
+    ]);
+  });
+});
+

--- a/mdm-platform/apps/api/src/modules/partners/__tests__/sap-sync.service.spec.ts
+++ b/mdm-platform/apps/api/src/modules/partners/__tests__/sap-sync.service.spec.ts
@@ -1,0 +1,213 @@
+import "reflect-metadata";
+import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../entities/partner.entity", () => ({ Partner: class Partner {} }));
+vi.mock("../entities/partner-audit-log.entity", () => ({ PartnerAuditLog: class PartnerAuditLog {} }));
+vi.mock("../entities/partner-audit-job.entity", () => ({ PartnerAuditJob: class PartnerAuditJob {} }));
+
+let SapSyncService: typeof import("../sap-sync.service").SapSyncService;
+
+beforeAll(async () => {
+  ({ SapSyncService } = await import("../sap-sync.service"));
+});
+
+const originalEnv = {
+  SAP_BASE_URL: process.env.SAP_BASE_URL,
+  SAP_USER: process.env.SAP_USER,
+  SAP_PASSWORD: process.env.SAP_PASSWORD,
+  SAP_SYNC_ENABLED: process.env.SAP_SYNC_ENABLED,
+  SAP_REQUEST_TIMEOUT: process.env.SAP_REQUEST_TIMEOUT
+};
+
+const mockResponse = (body: any, status = 200) => ({
+  ok: status >= 200 && status < 300,
+  status,
+  json: async () => body,
+  text: async () => JSON.stringify(body)
+});
+
+type PartnerEntity = {
+  id: string;
+  mdmPartnerId: number;
+  sapBusinessPartnerId: string | null;
+  tipo_pessoa: "PJ" | "PF";
+  natureza: "cliente" | "fornecedor" | "ambos";
+  status: string;
+  nome_legal: string;
+  nome_fantasia?: string | null;
+  documento: string;
+  contato_principal: any;
+  comunicacao: any;
+  addresses: any[];
+  banks: any[];
+  fornecedor_info: any;
+  vendas_info: any;
+  fiscal_info: any;
+  transportadores: any[];
+  credito_info: any;
+  sap_segments: any[];
+};
+
+class FakePartnerRepository {
+  private store = new Map<string, PartnerEntity>();
+
+  constructor(initial: PartnerEntity[]) {
+    initial.forEach((partner) => this.store.set(partner.id, { ...partner }));
+  }
+
+  async findOne({ where }: { where: Partial<PartnerEntity> }): Promise<PartnerEntity | null> {
+    const [field, value] = Object.entries(where)[0] ?? [];
+    if (!field) return null;
+    for (const partner of this.store.values()) {
+      if ((partner as any)[field] === value) {
+        return partner;
+      }
+    }
+    return null;
+  }
+
+  merge(entity: PartnerEntity, updates: Partial<PartnerEntity>) {
+    Object.assign(entity, updates);
+    return entity;
+  }
+
+  async save(entity: PartnerEntity): Promise<PartnerEntity> {
+    this.store.set(entity.id, { ...entity });
+    return entity;
+  }
+}
+
+class FakeAuditLogRepository {
+  public entries: any[] = [];
+
+  async save(entry: any): Promise<any> {
+    this.entries.push(entry);
+    return entry;
+  }
+}
+
+class FakeAuditJobRepository {
+  public jobs: any[] = [];
+
+  create(data: any): any {
+    return {
+      id: `job-${this.jobs.length + 1}`,
+      scope: data.scope ?? "massa",
+      status: data.status ?? "queued",
+      partnerIds: data.partnerIds ?? [],
+      requestedBy: data.requestedBy,
+      startedAt: data.startedAt,
+      finishedAt: data.finishedAt,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+      logs: []
+    };
+  }
+
+  async save(job: any): Promise<any> {
+    this.jobs.push(job);
+    return job;
+  }
+
+  async update(id: string, data: any): Promise<void> {
+    const job = this.jobs.find((item) => item.id === id);
+    if (!job) return;
+    Object.assign(job, data);
+    job.updatedAt = new Date();
+  }
+}
+
+describe("SapSyncService", () => {
+  beforeEach(() => {
+    process.env.SAP_BASE_URL = "https://sap.example";
+    process.env.SAP_USER = "user";
+    process.env.SAP_PASSWORD = "secret";
+    process.env.SAP_SYNC_ENABLED = "true";
+    delete process.env.SAP_REQUEST_TIMEOUT;
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    Object.entries(originalEnv).forEach(([key, value]) => {
+      if (value === undefined) {
+        delete (process.env as any)[key];
+      } else {
+        process.env[key] = value as string;
+      }
+    });
+  });
+
+  it("updates partners from SAP and records audit logs", async () => {
+    const partner: PartnerEntity = {
+      id: "partner-1",
+      mdmPartnerId: 1000,
+      sapBusinessPartnerId: null as any,
+      tipo_pessoa: "PJ",
+      natureza: "cliente",
+      status: "draft",
+      nome_legal: "Empresa Original",
+      nome_fantasia: "Orig",
+      documento: "12345678000190",
+      contato_principal: { nome: "Old", email: "old@example.com" },
+      comunicacao: {},
+      addresses: [],
+      banks: [],
+      fornecedor_info: {},
+      vendas_info: {},
+      fiscal_info: {},
+      transportadores: [],
+      credito_info: {},
+      sap_segments: []
+    };
+
+    const partnerRepo = new FakePartnerRepository([partner]);
+    const auditLogRepo = new FakeAuditLogRepository();
+    const auditJobRepo = new FakeAuditJobRepository();
+
+    const service = new SapSyncService(
+      partnerRepo as any,
+      auditLogRepo as any,
+      auditJobRepo as any
+    );
+
+    const payloadPage = {
+      items: [
+        {
+          partnerId: "partner-1",
+          sapBusinessPartnerId: "BP-500",
+          legalName: "Empresa Atualizada",
+          contact: { name: "Novo", email: "novo@example.com", phone: "55110000" },
+          banks: [{ banco: "001", agencia: "1234", conta: "56789" }],
+          sapSegments: [{ segment: "businessPartner", status: "success", sapId: "BP-500" }]
+        }
+      ],
+      pagination: { page: 1, totalPages: 1 }
+    };
+
+    const fetchMock = vi.fn().mockResolvedValue(mockResponse(payloadPage));
+    vi.stubGlobal("fetch", fetchMock);
+
+    const summary = await service.syncPartners();
+
+    expect(summary.fetched).toBe(1);
+    expect(summary.updated).toBe(1);
+    expect(summary.errors).toBe(0);
+
+    const stored = await partnerRepo.findOne({ where: { id: "partner-1" } });
+    expect(stored?.sapBusinessPartnerId).toBe("BP-500");
+    expect(stored?.nome_legal).toBe("Empresa Atualizada");
+    expect(stored?.banks).toEqual([{ banco: "001", agencia: "1234", conta: "56789" }]);
+    expect(stored?.sap_segments).toEqual([
+      { segment: "businessPartner", status: "success", sapId: "BP-500" }
+    ]);
+
+    expect(auditJobRepo.jobs.length).toBe(1);
+    expect(auditLogRepo.entries).toHaveLength(1);
+    expect(auditLogRepo.entries[0]).toMatchObject({
+      partnerId: "partner-1",
+      message: expect.stringContaining("SAP"),
+      differences: expect.any(Array)
+    });
+  });
+});
+

--- a/mdm-platform/apps/api/src/modules/partners/partners.module.ts
+++ b/mdm-platform/apps/api/src/modules/partners/partners.module.ts
@@ -8,13 +8,14 @@ import { PartnersService } from './partners.service';
 import { PartnersController } from './partners.controller';
 import { AuthModule } from '../auth/auth.module';
 import { SapIntegrationService } from './sap-integration.service';
+import { SapSyncService } from './sap-sync.service';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([Partner, PartnerChangeRequest, PartnerAuditJob, PartnerAuditLog]),
     AuthModule,
   ],
-  providers: [PartnersService, SapIntegrationService],
+  providers: [PartnersService, SapIntegrationService, SapSyncService],
   controllers: [PartnersController],
 })
 export class PartnersModule {}

--- a/mdm-platform/apps/api/src/modules/partners/sap-integration.service.ts
+++ b/mdm-platform/apps/api/src/modules/partners/sap-integration.service.ts
@@ -43,7 +43,7 @@ export class SapIntegrationService {
       return { segments: states, completed: true, updates: {} };
     }
 
-    if (!this.isEnabled()) {
+    if (!this.isEnabled) {
       const now = new Date().toISOString();
       states = states.map((state) =>
         segments.includes(state.segment)
@@ -61,7 +61,7 @@ export class SapIntegrationService {
       return { segments: states, completed: true, updates: {} };
     }
 
-    if (!this.isConfigured()) {
+    if (!this.isConfigured) {
       const now = new Date().toISOString();
       const message = "Configuração SAP incompleta. Defina SAP_BASE_URL, SAP_USER e SAP_PASSWORD.";
       states = states.map((state) =>

--- a/mdm-platform/apps/api/src/modules/partners/sap-sync.mapper.ts
+++ b/mdm-platform/apps/api/src/modules/partners/sap-sync.mapper.ts
@@ -1,0 +1,262 @@
+import { SapIntegrationSegment } from "@mdm/types";
+import { Partner } from "./entities/partner.entity";
+
+type AllowedSegment = SapIntegrationSegment | string;
+
+export interface SapPartnerContactPayload {
+  name?: string | null;
+  email?: string | null;
+  phone?: string | null;
+}
+
+export interface SapPartnerCommunicationPayload {
+  phone?: string | null;
+  mobile?: string | null;
+  emails?: Array<{ address?: string | null; default?: boolean | null }> | null;
+}
+
+export interface SapPartnerPayload {
+  id?: string;
+  mdmPartnerId?: number | string | null;
+  partnerId?: string | null;
+  businessPartnerId?: string | number | null;
+  sapId?: string | number | null;
+  sapBusinessPartnerId?: string | number | null;
+  document?: string | null;
+  legalName?: string | null;
+  tradeName?: string | null;
+  personType?: Partner["tipo_pessoa"] | string | null;
+  nature?: Partner["natureza"] | string | null;
+  status?: Partner["status"] | string | null;
+  contact?: SapPartnerContactPayload | null;
+  communication?: SapPartnerCommunicationPayload | null;
+  addresses?: any[] | null;
+  banks?: any[] | null;
+  vendor?: Partner["fornecedor_info"] | null;
+  sales?: Partner["vendas_info"] | null;
+  fiscal?: Partner["fiscal_info"] | null;
+  credit?: Partner["credito_info"] | null;
+  transporters?: Partner["transportadores"] | null;
+  segments?: any[] | null;
+  sapSegments?: any[] | null;
+  sap_segments?: any[] | null;
+  sapIntegration?: { segments?: any[] | null } | null;
+}
+
+const ALLOWED_SEGMENTS: AllowedSegment[] = [
+  "businessPartner",
+  "addresses",
+  "roles",
+  "banks"
+];
+
+const ALLOWED_STATUSES = ["pending", "processing", "success", "error"];
+
+const coerceString = (value: string | number | null | undefined): string | undefined => {
+  if (value === undefined || value === null) {
+    return undefined;
+  }
+  const stringValue = String(value).trim();
+  return stringValue.length ? stringValue : undefined;
+};
+
+const coerceEnum = <T extends string>(value: string | null | undefined, allowed: readonly T[]): T | undefined => {
+  if (!value) return undefined;
+  const normalized = value.trim();
+  return allowed.includes(normalized as T) ? (normalized as T) : undefined;
+};
+
+const sanitizeEmails = (
+  payload: SapPartnerCommunicationPayload | null | undefined
+): Partner["comunicacao"] | undefined => {
+  if (!payload) return undefined;
+  const emails = Array.isArray(payload.emails)
+    ? payload.emails
+        .map((email) => {
+          const address = coerceString(email?.address);
+          if (!address) return null;
+          return { endereco: address, padrao: Boolean(email?.default ?? false) };
+        })
+        .filter((item): item is { endereco: string; padrao?: boolean } => Boolean(item))
+    : undefined;
+
+  const normalized: Partner["comunicacao"] = {};
+  if (payload.phone) {
+    normalized.telefone = String(payload.phone);
+  }
+  if (payload.mobile) {
+    normalized.celular = String(payload.mobile);
+  }
+  if (emails?.length) {
+    normalized.emails = emails;
+  }
+
+  return Object.keys(normalized).length ? normalized : undefined;
+};
+
+const sanitizeContact = (
+  payload: SapPartnerContactPayload | null | undefined
+): Partner["contato_principal"] | undefined => {
+  if (!payload) return undefined;
+  const normalized: Partner["contato_principal"] = {
+    nome: payload.name ? String(payload.name) : "",
+    email: payload.email ? String(payload.email) : ""
+  } as Partner["contato_principal"];
+
+  if (!normalized.nome) delete (normalized as any).nome;
+  if (!normalized.email) delete (normalized as any).email;
+  if (payload.phone) {
+    normalized.fone = String(payload.phone);
+  }
+
+  return Object.keys(normalized).length ? normalized : undefined;
+};
+
+const sanitizeSegments = (payload: SapPartnerPayload): Partner["sap_segments"] | undefined => {
+  const sources = [
+    payload.sapSegments,
+    payload.segments,
+    payload.sap_segments,
+    payload.sapIntegration?.segments
+  ];
+
+  const rawSegments = sources.find((entry) => Array.isArray(entry));
+  if (!Array.isArray(rawSegments)) {
+    return undefined;
+  }
+
+  const allowedSegments = new Set(ALLOWED_SEGMENTS.map(String));
+
+  const sanitized = rawSegments
+    .map((entry) => {
+      if (!entry || typeof entry !== "object") return null;
+      const segment = coerceString((entry as any).segment ?? (entry as any).code ?? (entry as any).name);
+      if (!segment || !allowedSegments.has(segment)) {
+        return null;
+      }
+      const status = coerceEnum((entry as any).status, ALLOWED_STATUSES as any);
+      const normalizedStatus = status ?? "pending";
+      const record: Partner["sap_segments"][number] = {
+        segment: segment as SapIntegrationSegment,
+        status: normalizedStatus as any
+      };
+
+      const lastAttempt = (entry as any).lastAttemptAt ?? (entry as any).last_attempt_at ?? (entry as any).lastAttempt;
+      const lastSuccess = (entry as any).lastSuccessAt ?? (entry as any).last_success_at ?? (entry as any).lastSuccess;
+      const message = (entry as any).message;
+      const errorMessage = (entry as any).errorMessage ?? (entry as any).error_message;
+      const sapId = (entry as any).sapId ?? (entry as any).sap_id ?? (entry as any).id;
+
+      if (lastAttempt) record.lastAttemptAt = String(lastAttempt);
+      if (lastSuccess) record.lastSuccessAt = String(lastSuccess);
+      if (message) record.message = String(message);
+      if (errorMessage) record.errorMessage = String(errorMessage);
+      const normalizedSapId = coerceString(sapId);
+      if (normalizedSapId) record.sapId = normalizedSapId;
+
+      return record;
+    })
+    .filter((item): item is Partner["sap_segments"][number] => Boolean(item));
+
+  if (!sanitized.length) {
+    return undefined;
+  }
+
+  return sanitized.sort((a, b) => a.segment.localeCompare(b.segment));
+};
+
+export const mapSapPartnerPayload = (payload: SapPartnerPayload): Partial<Partner> => {
+  const updates: Partial<Partner> = {};
+
+  const sapId =
+    coerceString(payload.sapBusinessPartnerId) ??
+    coerceString(payload.sapId) ??
+    coerceString(payload.businessPartnerId);
+  if (sapId) {
+    updates.sapBusinessPartnerId = sapId;
+  }
+
+  const legalName = coerceString(payload.legalName);
+  if (legalName) {
+    updates.nome_legal = legalName;
+  }
+
+  const tradeName = coerceString(payload.tradeName);
+  if (tradeName) {
+    updates.nome_fantasia = tradeName;
+  }
+
+  const document = coerceString(payload.document);
+  if (document) {
+    updates.documento = document;
+  }
+
+  const personType = coerceEnum(payload.personType as string, ["PJ", "PF"]);
+  if (personType) {
+    updates.tipo_pessoa = personType;
+  }
+
+  const nature = coerceEnum(payload.nature as string, ["cliente", "fornecedor", "ambos"]);
+  if (nature) {
+    updates.natureza = nature;
+  }
+
+  const status = coerceEnum(payload.status as string, [
+    "draft",
+    "em_validacao",
+    "aprovado",
+    "rejeitado",
+    "integrado"
+  ]);
+  if (status) {
+    updates.status = status;
+  }
+
+  const contact = sanitizeContact(payload.contact);
+  if (contact) {
+    updates.contato_principal = contact;
+  }
+
+  const communication = sanitizeEmails(payload.communication);
+  if (communication) {
+    updates.comunicacao = communication;
+  }
+
+  if (Array.isArray(payload.addresses)) {
+    updates.addresses = payload.addresses;
+  }
+
+  if (Array.isArray(payload.banks)) {
+    updates.banks = payload.banks;
+  }
+
+  if (payload.vendor && typeof payload.vendor === "object") {
+    updates.fornecedor_info = payload.vendor as Partner["fornecedor_info"];
+  }
+
+  if (payload.sales && typeof payload.sales === "object") {
+    updates.vendas_info = payload.sales as Partner["vendas_info"];
+  }
+
+  if (payload.fiscal && typeof payload.fiscal === "object") {
+    updates.fiscal_info = payload.fiscal as Partner["fiscal_info"];
+  }
+
+  if (payload.credit && typeof payload.credit === "object") {
+    updates.credito_info = payload.credit as Partner["credito_info"];
+  }
+
+  if (Array.isArray(payload.transporters)) {
+    updates.transportadores = payload.transporters as Partner["transportadores"];
+  }
+
+  const segments = sanitizeSegments(payload);
+  if (segments) {
+    updates.sap_segments = segments;
+  }
+
+  return updates;
+};
+
+export type SapPartnerUpdate = ReturnType<typeof mapSapPartnerPayload>;
+

--- a/mdm-platform/apps/api/src/modules/partners/sap-sync.service.ts
+++ b/mdm-platform/apps/api/src/modules/partners/sap-sync.service.ts
@@ -1,0 +1,378 @@
+import { Injectable, Logger } from "@nestjs/common";
+import { Cron, CronExpression } from "@nestjs/schedule";
+import { InjectRepository } from "@nestjs/typeorm";
+import { Partner } from "./entities/partner.entity";
+import { PartnerAuditLog } from "./entities/partner-audit-log.entity";
+import { PartnerAuditJob } from "./entities/partner-audit-job.entity";
+import { Repository } from "typeorm";
+import { mapSapPartnerPayload, SapPartnerPayload, SapPartnerUpdate } from "./sap-sync.mapper";
+import { PartnerAuditDifference } from "@mdm/types";
+import { onlyDigits } from "@mdm/utils";
+
+const SAP_SYNC_CRON = process.env.SAP_SYNC_CRON ?? CronExpression.EVERY_HOUR;
+
+export type SapSyncSummary = {
+  fetched: number;
+  updated: number;
+  skipped: number;
+  errors: number;
+};
+
+type SyncContext = {
+  job: PartnerAuditJob | null;
+  partnerIds: Set<string>;
+};
+
+@Injectable()
+export class SapSyncService {
+  private readonly logger = new Logger(SapSyncService.name);
+
+  constructor(
+    @InjectRepository(Partner) private readonly partnerRepo: Repository<Partner>,
+    @InjectRepository(PartnerAuditLog) private readonly auditLogRepo: Repository<PartnerAuditLog>,
+    @InjectRepository(PartnerAuditJob) private readonly auditJobRepo: Repository<PartnerAuditJob>
+  ) {}
+
+  @Cron(SAP_SYNC_CRON)
+  async handleCron() {
+    if (!this.isEnabled()) {
+      return;
+    }
+    try {
+      const summary = await this.syncPartners();
+      this.logger.log(
+        `Sincronização SAP concluída. Fetched=${summary.fetched} updated=${summary.updated} skipped=${summary.skipped} errors=${summary.errors}`
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      this.logger.error(`Erro na sincronização com o SAP: ${message}`, error instanceof Error ? error.stack : undefined);
+    }
+  }
+
+  async syncPartners(): Promise<SapSyncSummary> {
+    if (!this.isEnabled()) {
+      this.logger.debug("Sincronização SAP desativada (SAP_SYNC_ENABLED=false)");
+      return { fetched: 0, updated: 0, skipped: 0, errors: 0 };
+    }
+
+    if (!this.isConfigured()) {
+      this.logger.warn("Configuração do SAP incompleta. Defina SAP_BASE_URL, SAP_USER e SAP_PASSWORD.");
+      return { fetched: 0, updated: 0, skipped: 0, errors: 0 };
+    }
+
+    const summary: SapSyncSummary = { fetched: 0, updated: 0, skipped: 0, errors: 0 };
+    const context: SyncContext = { job: null, partnerIds: new Set() };
+    const pageSize = this.pageSize;
+
+    let page = 1;
+    let keepFetching = true;
+
+    while (keepFetching) {
+      const response = await this.fetchPartnerPage(page, pageSize).catch((error) => {
+        summary.errors += 1;
+        throw error;
+      });
+
+      const items = this.extractItems(response);
+      if (!items.length && page === 1) {
+        break;
+      }
+
+      for (const payload of items) {
+        summary.fetched += 1;
+        try {
+          const processed = await this.processPartnerPayload(payload, context);
+          if (processed) {
+            summary.updated += 1;
+          } else {
+            summary.skipped += 1;
+          }
+        } catch (error) {
+          summary.errors += 1;
+          const message = error instanceof Error ? error.message : String(error);
+          this.logger.error(`Erro ao processar payload SAP: ${message}`, error instanceof Error ? error.stack : undefined);
+        }
+      }
+
+      keepFetching = this.hasNextPage(response, items.length, pageSize, page);
+      page += 1;
+    }
+
+    if (context.job) {
+      await this.auditJobRepo.update(context.job.id, {
+        status: "concluido",
+        finishedAt: new Date(),
+        partnerIds: Array.from(context.partnerIds)
+      });
+    }
+
+    return summary;
+  }
+
+  private async processPartnerPayload(payload: SapPartnerPayload, context: SyncContext): Promise<boolean> {
+    const updates = mapSapPartnerPayload(payload);
+    if (!Object.keys(updates).length) {
+      return false;
+    }
+
+    const partner = await this.findPartner(payload);
+    if (!partner) {
+      this.logger.warn(
+        `Parceiro não encontrado para o payload do SAP. Chaves: partnerId=${payload.partnerId ?? payload.id} document=${payload.document}`
+      );
+      return false;
+    }
+
+    const differences = this.calculateDifferences(partner, updates);
+    if (!differences.length) {
+      return false;
+    }
+
+    this.partnerRepo.merge(partner, updates);
+    await this.partnerRepo.save(partner);
+
+    context.partnerIds.add(partner.id);
+    const job = await this.ensureJob(context);
+
+    await this.auditLogRepo.save({
+      jobId: job.id,
+      partnerId: partner.id,
+      result: "ok",
+      differences,
+      message: "Cadastro atualizado a partir do SAP",
+      externalData: {
+        source: "sap",
+        fetchedAt: new Date().toISOString(),
+        payload
+      }
+    });
+
+    return true;
+  }
+
+  private async ensureJob(context: SyncContext): Promise<PartnerAuditJob> {
+    if (context.job) {
+      return context.job;
+    }
+
+    const now = new Date();
+    const job = this.auditJobRepo.create({
+      scope: "massa",
+      status: "running",
+      partnerIds: [],
+      requestedBy: "sap-sync",
+      startedAt: now
+    });
+    context.job = await this.auditJobRepo.save(job);
+    return context.job;
+  }
+
+  private calculateDifferences(partner: Partner, updates: SapPartnerUpdate): PartnerAuditDifference[] {
+    const differences: PartnerAuditDifference[] = [];
+    for (const [field, after] of Object.entries(updates)) {
+      const before = (partner as any)[field];
+      if (this.areValuesEqual(before, after)) {
+        continue;
+      }
+      differences.push({
+        field,
+        label: this.getFieldLabel(field),
+        before: this.cloneValue(before),
+        after: this.cloneValue(after),
+        source: "external",
+        metadata: {
+          sourceSystem: "sap",
+          field
+        }
+      });
+    }
+    return differences;
+  }
+
+  private cloneValue(value: any) {
+    if (value === undefined) {
+      return null;
+    }
+    return JSON.parse(JSON.stringify(value));
+  }
+
+  private getFieldLabel(field: string): string {
+    const labels: Record<string, string> = {
+      sapBusinessPartnerId: "SAP Business Partner ID",
+      sap_segments: "Segmentos SAP",
+      addresses: "Endereços",
+      banks: "Bancos",
+      contato_principal: "Contato principal",
+      comunicacao: "Comunicação",
+      fornecedor_info: "Informações de fornecedor",
+      vendas_info: "Informações de vendas",
+      fiscal_info: "Informações fiscais",
+      transportadores: "Transportadores",
+      credito_info: "Informações de crédito",
+      nome_legal: "Nome legal",
+      nome_fantasia: "Nome fantasia",
+      documento: "Documento",
+      natureza: "Natureza",
+      tipo_pessoa: "Tipo de pessoa",
+      status: "Status"
+    };
+    return labels[field] ?? field;
+  }
+
+  private areValuesEqual(before: any, after: any): boolean {
+    const normalize = (value: any) => {
+      if (value === null || value === undefined) return null;
+      return JSON.parse(JSON.stringify(value));
+    };
+
+    return JSON.stringify(normalize(before)) === JSON.stringify(normalize(after));
+  }
+
+  private async findPartner(payload: SapPartnerPayload): Promise<Partner | null> {
+    const identifiers: Array<[string, any]> = [];
+    if (payload.partnerId || payload.id) {
+      identifiers.push(["id", payload.partnerId ?? payload.id]);
+    }
+    if (payload.mdmPartnerId) {
+      identifiers.push(["mdmPartnerId", Number(payload.mdmPartnerId)]);
+    }
+    const sapId =
+      payload.sapBusinessPartnerId ?? payload.sapId ?? payload.businessPartnerId;
+    if (sapId) {
+      identifiers.push(["sapBusinessPartnerId", String(sapId)]);
+    }
+    if (payload.document) {
+      identifiers.push(["documento", onlyDigits(String(payload.document))]);
+    }
+
+    for (const [field, value] of identifiers) {
+      if (value === undefined || value === null || value === "") {
+        continue;
+      }
+      const partner = await this.partnerRepo.findOne({ where: { [field]: value } as any });
+      if (partner) {
+        return partner;
+      }
+    }
+
+    return null;
+  }
+
+  private async fetchPartnerPage(page: number, pageSize: number): Promise<any> {
+    const url = new URL(`${this.baseUrl}/business-partners`);
+    url.searchParams.set("page", String(page));
+    url.searchParams.set("pageSize", String(pageSize));
+    const updatedAfter = this.updatedAfter;
+    if (updatedAfter) {
+      url.searchParams.set("updatedAfter", updatedAfter);
+    }
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.timeout ?? 15000);
+
+    try {
+      const response = await fetch(url.toString(), {
+        method: "GET",
+        headers: this.buildHeaders(),
+        signal: controller.signal
+      });
+
+      if (!response.ok) {
+        const raw = await response.text();
+        throw new Error(raw || `SAP respondeu com status ${response.status}`);
+      }
+
+      return response.json();
+    } catch (error: any) {
+      if (error?.name === "AbortError") {
+        throw new Error("Tempo limite excedido ao consultar o SAP");
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
+    }
+  }
+
+  private extractItems(response: any): SapPartnerPayload[] {
+    if (!response) return [];
+    if (Array.isArray(response)) {
+      return response as SapPartnerPayload[];
+    }
+    if (Array.isArray(response.items)) {
+      return response.items as SapPartnerPayload[];
+    }
+    if (Array.isArray(response.data)) {
+      return response.data as SapPartnerPayload[];
+    }
+    return [];
+  }
+
+  private hasNextPage(response: any, itemCount: number, pageSize: number, currentPage: number): boolean {
+    const pagination = response?.pagination ?? {};
+    if (typeof pagination.nextPage === "number") {
+      return pagination.nextPage > currentPage;
+    }
+    if (typeof pagination.hasNext === "boolean") {
+      return pagination.hasNext;
+    }
+    if (typeof pagination.totalPages === "number" && typeof pagination.page === "number") {
+      return pagination.page < pagination.totalPages;
+    }
+    return itemCount === pageSize;
+  }
+
+  private buildHeaders(): Record<string, string> {
+    const headers: Record<string, string> = { Accept: "application/json" };
+    const auth = this.authorizationHeader;
+    if (auth) {
+      headers.Authorization = auth;
+    }
+    return headers;
+  }
+
+  private isEnabled(): boolean {
+    return process.env.SAP_SYNC_ENABLED !== "false";
+  }
+
+  private isConfigured(): boolean {
+    return Boolean(this.baseUrl && this.user && this.password);
+  }
+
+  private get baseUrl(): string {
+    return (process.env.SAP_BASE_URL || "").replace(/\/$/, "");
+  }
+
+  private get user(): string {
+    return process.env.SAP_USER || "";
+  }
+
+  private get password(): string {
+    return process.env.SAP_PASSWORD || "";
+  }
+
+  private get pageSize(): number {
+    const raw = process.env.SAP_SYNC_PAGE_SIZE;
+    const parsed = raw ? Number(raw) : NaN;
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 50;
+  }
+
+  private get updatedAfter(): string | null {
+    return process.env.SAP_SYNC_UPDATED_AFTER || null;
+  }
+
+  private get timeout(): number | null {
+    const raw = process.env.SAP_REQUEST_TIMEOUT;
+    if (!raw) return 15000;
+    const parsed = Number(raw);
+    return Number.isFinite(parsed) && parsed > 0 ? parsed : 15000;
+  }
+
+  private get authorizationHeader(): string | null {
+    if (!this.user && !this.password) {
+      return null;
+    }
+    const token = Buffer.from(`${this.user}:${this.password}`).toString("base64");
+    return `Basic ${token}`;
+  }
+}
+

--- a/mdm-platform/pnpm-lock.yaml
+++ b/mdm-platform/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       typescript:
         specifier: ^5.9.2
         version: 5.9.2
+      vitest:
+        specifier: ^2.1.4
+        version: 2.1.9(@types/node@20.19.17)(terser@5.44.0)
 
   apps/web:
     dependencies:


### PR DESCRIPTION
## Summary
- add a SapSyncService that paginates SAP partner updates, applies the payload mapper, and records audit diffs
- wire the sync job into the partners module with scheduling, document the environment variables, and add mapping/unit tests
- ensure SAP integration getter usage is correct and add the vitest dev dependency required to run the API tests

## Testing
- pnpm --filter @mdm/api test

------
https://chatgpt.com/codex/tasks/task_e_68df1ad1bce88325a3a0a1e1cb6f402a