### PR TITLE
feat: support segmented sap integration

### DIFF
--- a/mdm-platform/apps/api/src/modules/partners/__tests__/audit-logs.spec.ts
+++ b/mdm-platform/apps/api/src/modules/partners/__tests__/audit-logs.spec.ts
@@ -22,6 +22,11 @@ describe("PartnersService audit processing", () => {
   const auditLogRepo = {
     save: vi.fn()
   };
+  const sapIntegration = {
+    integratePartner: vi.fn(),
+    retry: vi.fn(),
+    markSegmentsAsError: vi.fn().mockReturnValue([])
+  };
 
   let service: InstanceType<typeof PartnersService>;
 
@@ -33,7 +38,17 @@ describe("PartnersService audit processing", () => {
     auditJobRepo.update.mockReset();
     auditLogRepo.save.mockReset();
 
-    service = new PartnersService(repo as any, changeRepo as any, auditJobRepo as any, auditLogRepo as any);
+    sapIntegration.integratePartner.mockReset();
+    sapIntegration.retry.mockReset();
+    sapIntegration.markSegmentsAsError.mockClear();
+
+    service = new PartnersService(
+      repo as any,
+      changeRepo as any,
+      auditJobRepo as any,
+      auditLogRepo as any,
+      sapIntegration as any
+    );
   });
 
   it("persists differences when external data diverges", async () => {

--- a/mdm-platform/apps/api/src/modules/partners/__tests__/document-validation.spec.ts
+++ b/mdm-platform/apps/api/src/modules/partners/__tests__/document-validation.spec.ts
@@ -86,7 +86,8 @@ describe("PartnersService lookup", () => {
   const auditLogRepo = { save: vi.fn() };
   const sapIntegration = {
     integratePartner: vi.fn().mockResolvedValue({ segments: [], completed: true, updates: {} }),
-    retry: vi.fn().mockResolvedValue({ segments: [], completed: true, updates: {} })
+    retry: vi.fn().mockResolvedValue({ segments: [], completed: true, updates: {} }),
+    markSegmentsAsError: vi.fn().mockReturnValue([])
   };
 
   let service: PartnersService;
@@ -96,6 +97,7 @@ describe("PartnersService lookup", () => {
     repo.findOne.mockReset();
     sapIntegration.integratePartner.mockReset();
     sapIntegration.retry.mockReset();
+    sapIntegration.markSegmentsAsError.mockClear();
     service = new PartnersService(
       repo as any,
       changeRepo as any,


### PR DESCRIPTION
## Summary
- extend the SAP integration service to use PATCH payloads, capture SAP error details and expose helper utilities for marking segment failures
- refactor partner submission, approval and retry flows to run through the integration service, add a segment-specific trigger endpoint and enrich Swagger documentation
- update the partner details page to reload data via a shared loader and allow users to reprocess individual SAP segments while surfacing action feedback
- cover the new behaviour with updated unit tests for the integration service and adjusted partner service mocks

## Testing
- `pnpm --filter @mdm/api test`


------
https://chatgpt.com/codex/tasks/task_e_68df1d9932908325bdbf64c80ee289eb