### PR TITLE
docs: clarify SAP Business Partner integration

### DIFF
--- a/mdm-platform/README.md
+++ b/mdm-platform/README.md
@@ -20,10 +20,19 @@ Monorepo com **Next.js (web)** + **NestJS (api)** + **PostgreSQL** + **Docker co
 
 ### Sincronização automática com o SAP
 
+- A integração é baseada na [API SAP Business Partner](https://api.sap.com/api/API_BUSINESS_PARTNER/resource/Business_Partner), reutilizando os recursos públicos de criação e atualização de `BusinessPartner`, endereços, funções e bancos.
 - A API expõe um `SapSyncService` que periodicamente consulta o endpoint `/business-partners` do SAP para buscar cadastros e atualizações. O job roda por padrão a cada hora (`@Cron` com `SAP_SYNC_CRON` opcional) e respeita `SAP_SYNC_ENABLED=false` caso seja necessário desligar a sincronização.
 - Campos retornados pelo SAP são mapeados para a entidade `Partner` (ex.: `sapBusinessPartnerId`, `sap_segments`, `addresses`, `banks`, contato, comunicação etc.) e qualquer alteração é salva com auditoria (`PartnerAuditLog`) indicando os diffs vindos do SAP.
+- Segmentos implementados:
+  - `businessPartner`: cria o registro principal via recurso `BusinessPartner` e persiste o `sapBusinessPartnerId` retornado.
+  - `addresses`: atualiza `BusinessPartnerAddress` com os endereços associados.
+  - `roles`: envia as funções do parceiro (`BusinessPartnerRole`), respeitando a lógica de cliente/fornecedor/transportador em `sap-integration.service.ts`.
+  - `banks`: sincroniza contas bancárias (`BusinessPartnerBank`).
+  - Cada chamada usa autenticação Basic (`SAP_USER`/`SAP_PASSWORD`) sobre HTTPS; tokens bearer não são emitidos automaticamente, então o usuário/senha técnicos precisam ter acesso aos escopos correspondentes na API SAP.
 - Variáveis úteis:
   - `SAP_SYNC_ENABLED` (default `true`): controla tanto a integração quanto o job de leitura.
   - `SAP_SYNC_PAGE_SIZE` (default `50`): tamanho da página na paginação do SAP.
   - `SAP_SYNC_UPDATED_AFTER`: filtro opcional enviado ao SAP (`updatedAfter`).
   - `SAP_SYNC_CRON`: expressão cron opcional para customizar a frequência do job.
+  - `SAP_REQUEST_TIMEOUT`: timeout de chamadas síncronas (ms, default `15000`).
+- Para estudar o mapeamento completo consulte `apps/api/src/modules/partners/sap-integration.service.ts` (montagem dos payloads e segmentos) e `apps/api/src/modules/partners/sap-sync.mapper.ts` (transformação das respostas de leitura).


### PR DESCRIPTION
## Summary
- reference the official SAP Business Partner API in the synchronization docs
- describe how the existing integration segments map to SAP resources and authentication behavior
- point readers to the mapping files and mention the timeout configuration variable

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68df24eb0cac83259e3dd21b3286af48