### PR TITLE
Configure global validation pipe for API

### DIFF
--- a/mdm-platform/apps/api/src/main.ts
+++ b/mdm-platform/apps/api/src/main.ts
@@ -1,9 +1,16 @@
+import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
-import { AppModule } from './app.module';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
+import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, { cors: true });
+  app.useGlobalPipes(
+    new ValidationPipe({
+      whitelist: true,
+      transform: true,
+    }),
+  );
   const config = new DocumentBuilder()
     .setTitle('MDM API')
     .setDescription('API de GestÃ£o de Dados Mestres')

--- a/mdm-platform/apps/api/src/main.validation.spec.ts
+++ b/mdm-platform/apps/api/src/main.validation.spec.ts
@@ -1,0 +1,67 @@
+import "reflect-metadata";
+
+import { ValidationPipe, BadRequestException } from "@nestjs/common";
+import { describe, expect, it } from "vitest";
+
+import { CreatePartnerDto } from "./modules/partners/dto/create-partner.dto";
+
+const basePayload = {
+  tipo_pessoa: "PJ" as const,
+  natureza: "cliente" as const,
+  nome_legal: "Empresa Teste",
+  documento: "45.723.174/0001-10",
+  contato_principal: {
+    nome: "Fulano de Tal",
+    email: "fulano@example.com"
+  },
+  comunicacao: {
+    emails: [{ endereco: "contato@example.com" }]
+  },
+  addresses: [
+    {
+      cep: "01001-000",
+      logradouro: "Rua Teste",
+      numero: "123",
+      bairro: "Centro",
+      municipio: "São Paulo",
+      uf: "SP"
+    }
+  ]
+};
+
+describe("Global ValidationPipe configuration", () => {
+  const pipe = new ValidationPipe({ whitelist: true, transform: true });
+
+  it("strips unknown fields from request bodies", async () => {
+    const result = await pipe.transform(
+      {
+        ...basePayload,
+        extraneous: "value"
+      },
+      { type: "body", metatype: CreatePartnerDto }
+    );
+
+    expect(result).not.toHaveProperty("extraneous");
+  });
+
+  it("returns validation messages for invalid payloads", async () => {
+    try {
+      await pipe.transform(
+        {
+          ...basePayload,
+          documento: "45.723.174/0001-11"
+        },
+        { type: "body", metatype: CreatePartnerDto }
+      );
+      throw new Error("expected validation error");
+    } catch (error) {
+      expect(error).toBeInstanceOf(BadRequestException);
+      const response = (error as BadRequestException).getResponse() as {
+        message?: string[];
+      };
+      expect(response?.message).toEqual(
+        expect.arrayContaining([expect.stringContaining("CNPJ inválido")])
+      );
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- register a global ValidationPipe with whitelist and transform options during Nest bootstrap
- add a regression test that ensures extra fields are stripped and validation errors are returned for invalid partner payloads

## Testing
- pnpm --filter @mdm/api test

------
https://chatgpt.com/codex/tasks/task_e_68dfced55d1c8325b103bad83bf6ea4e