### PR TITLE
Sanitize SAP partner document numbers in mapper

### DIFF
--- a/mdm-platform/apps/api/src/modules/partners/__tests__/sap-sync.mapper.spec.ts
+++ b/mdm-platform/apps/api/src/modules/partners/__tests__/sap-sync.mapper.spec.ts
@@ -34,7 +34,8 @@ describe("mapSapPartnerPayload", () => {
     expect(result.sapBusinessPartnerId).toBe("BP-001");
     expect(result.nome_legal).toBe("Empresa X");
     expect(result.nome_fantasia).toBe("X LTDA");
-    expect(result.documento).toBe("12.345.678/0001-99");
+    expect(result.documento).toBe("12345678000199");
+    expect(result.documento).toMatch(/^\d+$/);
     expect(result.tipo_pessoa).toBe("PJ");
     expect(result.natureza).toBe("cliente");
     expect(result.status).toBe("integrado");

--- a/mdm-platform/apps/api/src/modules/partners/sap-sync.mapper.ts
+++ b/mdm-platform/apps/api/src/modules/partners/sap-sync.mapper.ts
@@ -1,3 +1,4 @@
+import { onlyDigits } from "@mdm/utils";
 import { SapIntegrationSegment } from "@mdm/types";
 import { Partner } from "./entities/partner.entity";
 
@@ -188,7 +189,10 @@ export const mapSapPartnerPayload = (payload: SapPartnerPayload): Partial<Partne
 
   const document = coerceString(payload.document);
   if (document) {
-    updates.documento = document;
+    const digits = onlyDigits(document);
+    if (digits) {
+      updates.documento = digits;
+    }
   }
 
   const personType = coerceEnum(payload.personType as string, ["PJ", "PF"]);


### PR DESCRIPTION
## Summary
- sanitize incoming SAP partner document numbers using onlyDigits before storing
- update the SAP sync mapper spec to assert formatted documents are normalized to digits only

## Testing
- pnpm --filter @mdm/api test -- src/modules/partners/__tests__/sap-sync.mapper.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68dfd160cce4832582dda3b120f18951