### PR TITLE
feat(web): surface partner identifiers and normalize details

### DIFF
--- a/mdm-platform/packages/types/src/partner.ts
+++ b/mdm-platform/packages/types/src/partner.ts
@@ -61,7 +61,9 @@ export const CommunicationEmailSchema = z.object({
 export const PartnerSchema = z.object({
   id: z.string().uuid().optional(),
   mdm_partner_id: z.number().optional(),
+  mdmPartnerId: z.number().optional(),
   sap_bp_id: z.string().optional(),
+  sapBusinessPartnerId: z.string().optional(),
   tipo_pessoa: z.enum(["PJ", "PF"]),
   natureza: z.enum(["cliente", "fornecedor", "ambos"]),
   status: z.enum(["draft", "em_validacao", "aprovado", "rejeitado", "integrado"]).default("draft"),


### PR DESCRIPTION
## Summary
- highlight the MDM and SAP identifiers next to the partner legal name and keep the footer summary focused on complementary status data
- normalize partner details after fetching so camelCase identifier fields are always populated alongside their snake_case counterparts
- expose camelCase identifier variants in the shared partner type to support the updated UI

## Testing
- pnpm --filter @mdm/web lint *(fails: repository still uses legacy ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe23a43b88325b0ddc7bdddb64124