### PR TITLE
feat: add partner notes endpoints and UI actions

### DIFF
--- a/mdm-platform/apps/api/src/modules/partners/dto/partner-note.dto.ts
+++ b/mdm-platform/apps/api/src/modules/partners/dto/partner-note.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsString, MaxLength } from "class-validator";
+
+export class CreatePartnerNoteDto {
+  @ApiProperty({ description: "Conteúdo da nota" })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  content!: string;
+}

--- a/mdm-platform/apps/api/src/modules/partners/entities/partner-note.entity.ts
+++ b/mdm-platform/apps/api/src/modules/partners/entities/partner-note.entity.ts
@@ -1,0 +1,26 @@
+import { Column, CreateDateColumn, Entity, ManyToOne, PrimaryGeneratedColumn } from "typeorm";
+import { Partner } from "./partner.entity";
+
+@Entity("partner_notes")
+export class PartnerNote {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ name: "partner_id", type: "uuid" })
+  partnerId!: string;
+
+  @ManyToOne(() => Partner, (partner) => partner.notes, { onDelete: "CASCADE" })
+  partner!: Partner;
+
+  @Column({ type: "text" })
+  content!: string;
+
+  @Column({ name: "created_by_id", type: "uuid", nullable: true })
+  createdById?: string | null;
+
+  @Column({ name: "created_by_name", type: "varchar", length: 255, nullable: true })
+  createdByName?: string | null;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt!: Date;
+}

--- a/mdm-platform/apps/api/src/modules/partners/entities/partner.entity.ts
+++ b/mdm-platform/apps/api/src/modules/partners/entities/partner.entity.ts
@@ -2,6 +2,7 @@ import { Column, CreateDateColumn, Entity, Generated, OneToMany, PrimaryGenerate
 import { PartnerApprovalHistoryEntry, PartnerApprovalStage, SapIntegrationSegmentState } from "@mdm/types";
 import { PartnerAuditLog } from "./partner-audit-log.entity";
 import { PartnerChangeRequest } from "./partner-change-request.entity";
+import { PartnerNote } from "./partner-note.entity";
 
 @Entity("business_partners")
 export class Partner {
@@ -111,4 +112,9 @@ export class Partner {
 
   @OneToMany(() => PartnerAuditLog, (log) => log.partner)
   auditLogs!: PartnerAuditLog[];
+
+  @OneToMany(() => PartnerNote, (note) => note.partner)
+  notes!: PartnerNote[];
+
+  recentNotesCount?: number;
 }

--- a/mdm-platform/apps/api/src/modules/partners/partners.controller.ts
+++ b/mdm-platform/apps/api/src/modules/partners/partners.controller.ts
@@ -6,6 +6,7 @@ import { CreatePartnerDto } from "./dto/create-partner.dto";
 import { ChangeRequestListQueryDto, CreateBulkChangeRequestDto, CreateChangeRequestDto } from "./dto/change-request.dto";
 import { AuthenticatedUser, PartnersService } from "./partners.service";
 import { SAP_INTEGRATION_SEGMENTS } from "./sap-integration.service";
+import { CreatePartnerNoteDto } from "./dto/partner-note.dto";
 
 class AuditRequestDto {
   partnerIds!: string[];
@@ -49,6 +50,16 @@ export class PartnersController {
   @Get(":id/details")
   getDetails(@Param("id") id: string) {
     return this.svc.getDetails(id);
+  }
+
+  @Get(":id/notes")
+  listNotes(@Param("id") id: string) {
+    return this.svc.listNotes(id);
+  }
+
+  @Post(":id/notes")
+  createNote(@Param("id") id: string, @Body() dto: CreatePartnerNoteDto, @Req() req: AuthenticatedRequest) {
+    return this.svc.createNote(id, dto, req.user);
   }
 
   @Post(":id/change-requests")

--- a/mdm-platform/apps/api/src/modules/partners/partners.module.ts
+++ b/mdm-platform/apps/api/src/modules/partners/partners.module.ts
@@ -9,10 +9,11 @@ import { PartnersController } from './partners.controller';
 import { AuthModule } from '../auth/auth.module';
 import { SapIntegrationService } from './sap-integration.service';
 import { SapSyncService } from './sap-sync.service';
+import { PartnerNote } from './entities/partner-note.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Partner, PartnerChangeRequest, PartnerAuditJob, PartnerAuditLog]),
+    TypeOrmModule.forFeature([Partner, PartnerChangeRequest, PartnerAuditJob, PartnerAuditLog, PartnerNote]),
     AuthModule,
   ],
   providers: [PartnersService, SapIntegrationService, SapSyncService],

--- a/mdm-platform/packages/types/src/index.ts
+++ b/mdm-platform/packages/types/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./partner";
 export * from "./change-request";
 export * from "./partner-audit";
+export * from "./partner-note";

--- a/mdm-platform/packages/types/src/partner-note.ts
+++ b/mdm-platform/packages/types/src/partner-note.ts
@@ -1,0 +1,17 @@
+import { z } from "zod";
+
+export const PartnerNoteSchema = z.object({
+  id: z.string().uuid(),
+  partnerId: z.string().uuid(),
+  content: z.string(),
+  createdById: z.string().uuid().nullable().optional(),
+  createdByName: z.string().nullable().optional(),
+  createdAt: z.string()
+});
+
+export const PartnerNoteInputSchema = z.object({
+  content: z.string().min(1).max(2000)
+});
+
+export type PartnerNote = z.infer<typeof PartnerNoteSchema>;
+export type PartnerNoteInput = z.infer<typeof PartnerNoteInputSchema>;


### PR DESCRIPTION
## Summary
- introduce a PartnerNote entity/repository with REST endpoints and include notes in partner details
- expose PartnerNote types and surface recent note counts in partner search results
- add an actions menu to the partners table with note creation modal and audit linking flow

## Testing
- pnpm --filter @mdm/api test
- pnpm --filter @mdm/web lint *(fails: ESLint configuration missing in repo)*

------
https://chatgpt.com/codex/tasks/task_e_68dfe56f04288325802d095810781c2d