### PR TITLE
Add navigation and API stubs for notifications and history

### DIFF
--- a/mdm-platform/apps/api/src/app.module.ts
+++ b/mdm-platform/apps/api/src/app.module.ts
@@ -4,6 +4,9 @@ import { TypeOrmModule, TypeOrmModuleOptions } from "@nestjs/typeorm";
 
 import { PartnersModule } from "./modules/partners/partners.module";
 import { AuthModule } from "./modules/auth/auth.module";
+import { NotificationsModule } from "./modules/notifications/notifications.module";
+import { UserMaintenanceModule } from "./modules/user-maintenance/user-maintenance.module";
+import { HistoryModule } from "./modules/history/history.module";
 
 const dbUrl = process.env.DATABASE_URL || "postgres://mdm:mdm@localhost:5432/mdm";
 
@@ -19,7 +22,10 @@ const typeOrmConfig: TypeOrmModuleOptions = {
     ScheduleModule.forRoot(),
     TypeOrmModule.forRoot(typeOrmConfig),
     PartnersModule,
-    AuthModule
+    AuthModule,
+    NotificationsModule,
+    UserMaintenanceModule,
+    HistoryModule
   ]
 })
 export class AppModule {}

--- a/mdm-platform/apps/api/src/modules/history/history.controller.ts
+++ b/mdm-platform/apps/api/src/modules/history/history.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiTags } from "@nestjs/swagger";
+import { AuthGuard } from "@nestjs/passport";
+
+import { HistoryService } from "./history.service";
+
+@ApiTags("history")
+@ApiBearerAuth()
+@UseGuards(AuthGuard("jwt"))
+@Controller("history")
+export class HistoryController {
+  constructor(private readonly service: HistoryService) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+}

--- a/mdm-platform/apps/api/src/modules/history/history.module.ts
+++ b/mdm-platform/apps/api/src/modules/history/history.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+
+import { AuthModule } from "../auth/auth.module";
+import { HistoryController } from "./history.controller";
+import { HistoryService } from "./history.service";
+
+@Module({
+  imports: [AuthModule],
+  controllers: [HistoryController],
+  providers: [HistoryService]
+})
+export class HistoryModule {}

--- a/mdm-platform/apps/api/src/modules/history/history.service.ts
+++ b/mdm-platform/apps/api/src/modules/history/history.service.ts
@@ -1,0 +1,74 @@
+import { Injectable } from "@nestjs/common";
+
+type Actor = {
+  id: string;
+  name: string;
+  email: string;
+};
+
+type EventLog = {
+  id: string;
+  eventType: string;
+  description: string;
+  createdAt: string;
+  actor?: Actor | null;
+  metadata?: Record<string, any> | null;
+};
+
+@Injectable()
+export class HistoryService {
+  private readonly events: EventLog[] = [
+    {
+      id: "e-001",
+      eventType: "partner.submitted",
+      description: "Parceiro Comercial Alpha submetido para validação.",
+      createdAt: new Date(Date.now() - 1000 * 60 * 60).toISOString(),
+      actor: {
+        id: "u-001",
+        name: "Ana Lima",
+        email: "ana.lima@example.com"
+      },
+      metadata: { partnerId: "p-001", approvalStage: "fiscal" }
+    },
+    {
+      id: "e-002",
+      eventType: "partner.stage.approved",
+      description: "Etapa Fiscal aprovada para o parceiro Comercial Alpha.",
+      createdAt: new Date(Date.now() - 1000 * 60 * 45).toISOString(),
+      actor: {
+        id: "u-001",
+        name: "Ana Lima",
+        email: "ana.lima@example.com"
+      },
+      metadata: { partnerId: "p-001", approvalStage: "fiscal" }
+    },
+    {
+      id: "e-003",
+      eventType: "integration.sap.triggered",
+      description: "Envio de dados mestre agendado para o parceiro Tech Serviços.",
+      createdAt: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
+      actor: {
+        id: "system",
+        name: "Agendador MDM",
+        email: "mdm-bot@example.com"
+      },
+      metadata: { partnerId: "p-010", segment: "dados_mestres" }
+    },
+    {
+      id: "e-004",
+      eventType: "user.permission.updated",
+      description: "Responsabilidade de Dados Mestres atribuída a Camila Duarte.",
+      createdAt: new Date(Date.now() - 1000 * 60 * 10).toISOString(),
+      actor: {
+        id: "u-005",
+        name: "Gestor MDM",
+        email: "gestor@example.com"
+      },
+      metadata: { userId: "u-003", responsibility: "partners.approval.dados_mestres" }
+    }
+  ];
+
+  list(): EventLog[] {
+    return this.events;
+  }
+}

--- a/mdm-platform/apps/api/src/modules/notifications/notifications.controller.ts
+++ b/mdm-platform/apps/api/src/modules/notifications/notifications.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiTags } from "@nestjs/swagger";
+import { AuthGuard } from "@nestjs/passport";
+
+import { NotificationsService } from "./notifications.service";
+
+@ApiTags("notifications")
+@ApiBearerAuth()
+@UseGuards(AuthGuard("jwt"))
+@Controller("notifications")
+export class NotificationsController {
+  constructor(private readonly service: NotificationsService) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+}

--- a/mdm-platform/apps/api/src/modules/notifications/notifications.module.ts
+++ b/mdm-platform/apps/api/src/modules/notifications/notifications.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+
+import { AuthModule } from "../auth/auth.module";
+import { NotificationsController } from "./notifications.controller";
+import { NotificationsService } from "./notifications.service";
+
+@Module({
+  imports: [AuthModule],
+  controllers: [NotificationsController],
+  providers: [NotificationsService]
+})
+export class NotificationsModule {}

--- a/mdm-platform/apps/api/src/modules/notifications/notifications.service.ts
+++ b/mdm-platform/apps/api/src/modules/notifications/notifications.service.ts
@@ -1,0 +1,43 @@
+import { Injectable } from "@nestjs/common";
+
+type NotificationItem = {
+  id: string;
+  title: string;
+  message: string;
+  createdAt: string;
+  read: boolean;
+  category?: string | null;
+};
+
+@Injectable()
+export class NotificationsService {
+  private readonly notifications: NotificationItem[] = [
+    {
+      id: "n-001",
+      title: "Parceiro aguardando validação",
+      message: "O parceiro Comercial Alpha aguarda ação na etapa Fiscal.",
+      category: "partners.approval.fiscal",
+      createdAt: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
+      read: false
+    },
+    {
+      id: "n-002",
+      title: "Integração concluída",
+      message: "O parceiro Tech Serviços foi integrado ao SAP com sucesso.",
+      category: "partners.approval.dados_mestres",
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 5).toISOString(),
+      read: true
+    },
+    {
+      id: "n-003",
+      title: "Atualização de fluxo",
+      message: "Novas responsabilidades foram atribuídas ao seu perfil de aprovador.",
+      createdAt: new Date(Date.now() - 1000 * 60 * 60 * 24).toISOString(),
+      read: true
+    }
+  ];
+
+  list(): NotificationItem[] {
+    return this.notifications;
+  }
+}

--- a/mdm-platform/apps/api/src/modules/user-maintenance/user-maintenance.controller.ts
+++ b/mdm-platform/apps/api/src/modules/user-maintenance/user-maintenance.controller.ts
@@ -1,0 +1,18 @@
+import { Controller, Get, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiTags } from "@nestjs/swagger";
+import { AuthGuard } from "@nestjs/passport";
+
+import { UserMaintenanceService } from "./user-maintenance.service";
+
+@ApiTags("user-maintenance")
+@ApiBearerAuth()
+@UseGuards(AuthGuard("jwt"))
+@Controller("user-maintenance")
+export class UserMaintenanceController {
+  constructor(private readonly service: UserMaintenanceService) {}
+
+  @Get()
+  list() {
+    return this.service.list();
+  }
+}

--- a/mdm-platform/apps/api/src/modules/user-maintenance/user-maintenance.module.ts
+++ b/mdm-platform/apps/api/src/modules/user-maintenance/user-maintenance.module.ts
@@ -1,0 +1,12 @@
+import { Module } from "@nestjs/common";
+
+import { AuthModule } from "../auth/auth.module";
+import { UserMaintenanceController } from "./user-maintenance.controller";
+import { UserMaintenanceService } from "./user-maintenance.service";
+
+@Module({
+  imports: [AuthModule],
+  controllers: [UserMaintenanceController],
+  providers: [UserMaintenanceService]
+})
+export class UserMaintenanceModule {}

--- a/mdm-platform/apps/api/src/modules/user-maintenance/user-maintenance.service.ts
+++ b/mdm-platform/apps/api/src/modules/user-maintenance/user-maintenance.service.ts
@@ -1,0 +1,57 @@
+import { Injectable } from "@nestjs/common";
+
+type ManagedUser = {
+  id: string;
+  name: string;
+  email: string;
+  profile: string | null;
+  responsibilities: string[];
+  status: "active" | "invited" | "blocked";
+  lastAccessAt?: string | null;
+};
+
+@Injectable()
+export class UserMaintenanceService {
+  private readonly users: ManagedUser[] = [
+    {
+      id: "u-001",
+      name: "Ana Lima",
+      email: "ana.lima@example.com",
+      profile: "fiscal",
+      responsibilities: ["partners.approval.fiscal"],
+      status: "active",
+      lastAccessAt: new Date(Date.now() - 1000 * 60 * 15).toISOString()
+    },
+    {
+      id: "u-002",
+      name: "Bruno Carvalho",
+      email: "bruno.carvalho@example.com",
+      profile: "compras",
+      responsibilities: ["partners.approval.compras"],
+      status: "active",
+      lastAccessAt: new Date(Date.now() - 1000 * 60 * 60 * 36).toISOString()
+    },
+    {
+      id: "u-003",
+      name: "Camila Duarte",
+      email: "camila.duarte@example.com",
+      profile: "dados_mestres",
+      responsibilities: ["partners.approval.dados_mestres"],
+      status: "invited",
+      lastAccessAt: null
+    },
+    {
+      id: "u-004",
+      name: "Daniel Freitas",
+      email: "daniel.freitas@example.com",
+      profile: null,
+      responsibilities: [],
+      status: "blocked",
+      lastAccessAt: new Date(Date.now() - 1000 * 60 * 60 * 24 * 20).toISOString()
+    }
+  ];
+
+  list(): ManagedUser[] {
+    return this.users;
+  }
+}

--- a/mdm-platform/apps/web/src/app/(protected)/history/page.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/history/page.tsx
@@ -1,0 +1,156 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import axios from "axios";
+import { useRouter } from "next/navigation";
+import { Clock3 } from "lucide-react";
+
+type EventLog = {
+  id: string;
+  eventType: string;
+  description: string;
+  createdAt: string;
+  actor?: {
+    id: string;
+    name: string;
+    email: string;
+  } | null;
+  metadata?: Record<string, any> | null;
+};
+
+type EventLogResponse = EventLog[];
+
+export default function HistoryPage() {
+  const router = useRouter();
+  const [events, setEvents] = useState<EventLog[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchHistory = async () => {
+      const token = localStorage.getItem("mdmToken");
+      if (!token) {
+        router.replace("/login");
+        return;
+      }
+
+      try {
+        const response = await axios.get<EventLogResponse>(`${process.env.NEXT_PUBLIC_API_URL}/history`, {
+          headers: { Authorization: `Bearer ${token}` }
+        });
+        const data = Array.isArray(response.data) ? response.data : [];
+        setEvents(data);
+        setError(null);
+      } catch (err: any) {
+        if (err?.response?.status === 401) {
+          localStorage.removeItem("mdmToken");
+          router.replace("/login");
+          return;
+        }
+        const message = err?.response?.data?.message;
+        setError(typeof message === "string" ? message : "Não foi possível carregar o histórico de eventos.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchHistory();
+  }, [router]);
+
+  const groupedEvents = useMemo(() => {
+    const groups = new Map<string, EventLog[]>();
+    events.forEach((event) => {
+      const date = event.createdAt ? new Date(event.createdAt).toISOString().split("T")[0] : "Sem data";
+      const existing = groups.get(date) ?? [];
+      existing.push(event);
+      groups.set(date, existing);
+    });
+    return Array.from(groups.entries()).sort(([a], [b]) => (a > b ? -1 : 1));
+  }, [events]);
+
+  return (
+    <main className="flex min-h-screen flex-col gap-6 bg-zinc-100 p-6">
+      <header className="flex flex-col gap-2">
+        <div className="flex items-center gap-2 text-zinc-900">
+          <Clock3 className="h-6 w-6" />
+          <h1 className="text-2xl font-semibold">Histórico de Eventos</h1>
+        </div>
+        <p className="text-sm text-zinc-500">
+          Consulte as ações realizadas pelos usuários e integrações dentro da plataforma de MDM.
+        </p>
+      </header>
+
+      {loading ? (
+        <section className="grid gap-3">
+          {Array.from({ length: 4 }).map((_, index) => (
+            <div key={index} className="h-24 animate-pulse rounded-2xl bg-white" />
+          ))}
+        </section>
+      ) : error ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+      ) : events.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center rounded-2xl border border-dashed border-zinc-300 bg-white p-10 text-center text-sm text-zinc-500">
+          Ainda não há eventos registrados.
+        </div>
+      ) : (
+        <section className="flex flex-col gap-4">
+          {groupedEvents.map(([date, entries]) => {
+            const formattedDate = date !== "Sem data"
+              ? new Date(date).toLocaleDateString("pt-BR", {
+                  day: "2-digit",
+                  month: "long",
+                  year: "numeric"
+                })
+              : date;
+
+            return (
+              <div key={date} className="space-y-3">
+                <div className="text-xs font-semibold uppercase tracking-wide text-zinc-400">{formattedDate}</div>
+                <div className="space-y-3">
+                  {entries
+                    .slice()
+                    .sort((a, b) => (a.createdAt > b.createdAt ? -1 : 1))
+                    .map((event) => {
+                      const createdAt = event.createdAt ? new Date(event.createdAt) : null;
+                      const createdAtLabel = createdAt?.toLocaleTimeString("pt-BR", {
+                        hour: "2-digit",
+                        minute: "2-digit"
+                      });
+                      return (
+                        <article key={event.id} className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
+                          <div className="flex flex-col gap-1">
+                            <div className="flex items-center justify-between">
+                              <h2 className="text-sm font-semibold text-zinc-900">{event.eventType}</h2>
+                              {createdAtLabel && (
+                                <time className="text-xs text-zinc-400" dateTime={createdAt?.toISOString()}>
+                                  {createdAtLabel}
+                                </time>
+                              )}
+                            </div>
+                            <p className="text-sm text-zinc-600">{event.description}</p>
+                            {event.actor ? (
+                              <span className="text-xs text-zinc-500">
+                                {event.actor.name} ({event.actor.email})
+                              </span>
+                            ) : null}
+                            {event.metadata && Object.keys(event.metadata).length > 0 ? (
+                              <details className="group mt-2 text-xs text-zinc-500">
+                                <summary className="cursor-pointer font-medium text-zinc-600">Detalhes</summary>
+                                <pre className="mt-1 overflow-x-auto rounded bg-zinc-50 p-2 text-[11px] leading-relaxed text-zinc-500">
+                                  {JSON.stringify(event.metadata, null, 2)}
+                                </pre>
+                              </details>
+                            ) : null}
+                          </div>
+                        </article>
+                      );
+                    })}
+                </div>
+              </div>
+            );
+          })}
+        </section>
+      )}
+    </main>
+  );
+}

--- a/mdm-platform/apps/web/src/app/(protected)/layout.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/layout.tsx
@@ -1,7 +1,7 @@
 ﻿"use client";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { Home, Users, PlusSquare, LogOut } from "lucide-react";
+import { Home, Users, PlusSquare, LogOut, Bell, UserCog, Clock3 } from "lucide-react";
 import { PropsWithChildren, useEffect, useMemo, useState } from "react";
 import { jwtDecode } from "jwt-decode";
 import { getStoredUser, storeUser, StoredUser } from "../../lib/auth";
@@ -18,7 +18,10 @@ type TokenPayload = {
 const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: Home },
   { href: "/partners", label: "Parceiros", icon: Users },
-  { href: "/partners/new", label: "Novo", icon: PlusSquare }
+  { href: "/partners/new", label: "Novo", icon: PlusSquare },
+  { href: "/notifications", label: "Notificações", icon: Bell },
+  { href: "/user-maintenance", label: "Usuários", icon: UserCog },
+  { href: "/history", label: "Histórico", icon: Clock3 }
 ];
 
 export default function ProtectedLayout({ children }: PropsWithChildren) {

--- a/mdm-platform/apps/web/src/app/(protected)/notifications/page.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/notifications/page.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import axios from "axios";
+import { useRouter } from "next/navigation";
+import { Bell } from "lucide-react";
+
+import { getStoredUser } from "../../../lib/auth";
+
+type NotificationItem = {
+  id: string;
+  title: string;
+  message: string;
+  createdAt: string;
+  read?: boolean;
+  category?: string | null;
+};
+
+type NotificationResponse = NotificationItem[];
+
+export default function NotificationsPage() {
+  const router = useRouter();
+  const [items, setItems] = useState<NotificationItem[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    const fetchNotifications = async () => {
+      const token = localStorage.getItem("mdmToken");
+      if (!token) {
+        router.replace("/login");
+        return;
+      }
+
+      try {
+        const response = await axios.get<NotificationResponse>(
+          `${process.env.NEXT_PUBLIC_API_URL}/notifications`,
+          {
+            headers: { Authorization: `Bearer ${token}` }
+          }
+        );
+        const data = Array.isArray(response.data) ? response.data : [];
+        setItems(data);
+        setError(null);
+      } catch (err: any) {
+        if (err?.response?.status === 401) {
+          localStorage.removeItem("mdmToken");
+          router.replace("/login");
+          return;
+        }
+        const message = err?.response?.data?.message;
+        setError(typeof message === "string" ? message : "Não foi possível carregar as notificações.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchNotifications();
+  }, [router]);
+
+  const unreadCount = useMemo(() => items.filter((item) => !item.read).length, [items]);
+  const storedUser = useMemo(() => getStoredUser(), []);
+
+  return (
+    <main className="flex min-h-screen flex-col gap-6 bg-zinc-100 p-6">
+      <header className="flex flex-col gap-2">
+        <div className="flex items-center gap-2 text-zinc-900">
+          <Bell className="h-6 w-6" />
+          <h1 className="text-2xl font-semibold">Notificações</h1>
+        </div>
+        <p className="text-sm text-zinc-500">Acompanhe os alertas e atualizações importantes do MDM.</p>
+        {items.length > 0 && (
+          <span className="text-xs font-medium uppercase tracking-wide text-zinc-400">
+            {unreadCount > 0 ? `${unreadCount} pendente(s)` : "Todas lidas"}
+          </span>
+        )}
+      </header>
+
+      {loading ? (
+        <section className="grid gap-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="h-20 animate-pulse rounded-xl bg-white" />
+          ))}
+        </section>
+      ) : error ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+      ) : items.length === 0 ? (
+        <div className="flex flex-1 flex-col items-center justify-center rounded-2xl border border-dashed border-zinc-300 bg-white p-10 text-center text-sm text-zinc-500">
+          Nenhuma notificação encontrada.
+        </div>
+      ) : (
+        <section className="grid gap-3">
+          {items.map((item) => {
+            const createdAt = item.createdAt ? new Date(item.createdAt) : null;
+            const formattedDate = createdAt?.toLocaleString("pt-BR", {
+              day: "2-digit",
+              month: "2-digit",
+              year: "numeric",
+              hour: "2-digit",
+              minute: "2-digit"
+            });
+
+            const isForCurrentProfile = item.category
+              ? storedUser?.responsibilities?.includes(item.category)
+              : true;
+
+            return (
+              <article
+                key={item.id}
+                className={`rounded-2xl border px-5 py-4 shadow-sm transition-colors ${
+                  item.read ? "border-zinc-200 bg-white" : "border-indigo-200 bg-indigo-50"
+                } ${!isForCurrentProfile ? "opacity-75" : ""}`}
+              >
+                <div className="flex items-start justify-between gap-4">
+                  <div className="flex flex-1 flex-col gap-1">
+                    <h2 className="text-base font-semibold text-zinc-900">{item.title}</h2>
+                    <p className="text-sm text-zinc-600">{item.message}</p>
+                    {item.category && (
+                      <span className="inline-flex w-fit items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium uppercase tracking-wide text-zinc-500">
+                        {item.category}
+                      </span>
+                    )}
+                  </div>
+                  {formattedDate && (
+                    <time className="shrink-0 text-xs text-zinc-400" dateTime={createdAt?.toISOString()}>
+                      {formattedDate}
+                    </time>
+                  )}
+                </div>
+              </article>
+            );
+          })}
+        </section>
+      )}
+    </main>
+  );
+}

--- a/mdm-platform/apps/web/src/app/(protected)/user-maintenance/page.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/user-maintenance/page.tsx
@@ -1,0 +1,186 @@
+"use client";
+
+import { useEffect, useMemo, useState } from "react";
+import axios from "axios";
+import { useRouter } from "next/navigation";
+import { UserCog } from "lucide-react";
+
+import { getStoredUser } from "../../../lib/auth";
+
+type ManagedUser = {
+  id: string;
+  name: string;
+  email: string;
+  profile: string | null;
+  responsibilities: string[];
+  status: "active" | "invited" | "blocked";
+  lastAccessAt?: string | null;
+};
+
+type ManagedUserResponse = ManagedUser[];
+
+const statusLabels: Record<ManagedUser["status"], string> = {
+  active: "Ativo",
+  invited: "Convite pendente",
+  blocked: "Bloqueado"
+};
+
+export default function UserMaintenancePage() {
+  const router = useRouter();
+  const [users, setUsers] = useState<ManagedUser[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const currentUser = useMemo(() => getStoredUser(), []);
+
+  useEffect(() => {
+    const fetchUsers = async () => {
+      const token = localStorage.getItem("mdmToken");
+      if (!token) {
+        router.replace("/login");
+        return;
+      }
+
+      try {
+        const response = await axios.get<ManagedUserResponse>(
+          `${process.env.NEXT_PUBLIC_API_URL}/user-maintenance`,
+          {
+            headers: { Authorization: `Bearer ${token}` }
+          }
+        );
+        const data = Array.isArray(response.data) ? response.data : [];
+        setUsers(data);
+        setError(null);
+      } catch (err: any) {
+        if (err?.response?.status === 401) {
+          localStorage.removeItem("mdmToken");
+          router.replace("/login");
+          return;
+        }
+        const message = err?.response?.data?.message;
+        setError(typeof message === "string" ? message : "Não foi possível carregar a lista de usuários.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchUsers();
+  }, [router]);
+
+  const metrics = useMemo(() => {
+    const totals = { active: 0, invited: 0, blocked: 0 } as Record<ManagedUser["status"], number>;
+    users.forEach((user) => {
+      totals[user.status] += 1;
+    });
+    return totals;
+  }, [users]);
+
+  return (
+    <main className="flex min-h-screen flex-col gap-6 bg-zinc-100 p-6">
+      <header className="flex flex-col gap-2">
+        <div className="flex items-center gap-2 text-zinc-900">
+          <UserCog className="h-6 w-6" />
+          <h1 className="text-2xl font-semibold">Manutenção de Usuários</h1>
+        </div>
+        <p className="text-sm text-zinc-500">
+          Visualize perfis, responsabilidades e status de acesso dos colaboradores que atuam no processo de MDM.
+        </p>
+        {currentUser?.responsibilities?.length ? (
+          <span className="text-xs uppercase tracking-wide text-zinc-400">
+            Você possui {currentUser.responsibilities.length} permissão(ões) vinculada(s).
+          </span>
+        ) : null}
+      </header>
+
+      {loading ? (
+        <section className="grid gap-4 md:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div key={index} className="h-24 animate-pulse rounded-2xl bg-white" />
+          ))}
+        </section>
+      ) : error ? (
+        <div className="rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">{error}</div>
+      ) : (
+        <>
+          <section className="grid gap-4 md:grid-cols-3">
+            {(Object.keys(metrics) as ManagedUser["status"][]).map((status) => (
+              <article key={status} className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
+                <span className="text-xs uppercase tracking-wide text-zinc-400">{statusLabels[status]}</span>
+                <strong className="mt-2 block text-3xl font-semibold text-zinc-900">{metrics[status]}</strong>
+              </article>
+            ))}
+          </section>
+
+          <section className="overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm">
+            <table className="min-w-full divide-y divide-zinc-200 text-left">
+              <thead className="bg-zinc-50">
+                <tr>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-zinc-500">Nome</th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-zinc-500">E-mail</th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-zinc-500">Perfil</th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-zinc-500">Responsabilidades</th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-zinc-500">Status</th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-zinc-500">Último acesso</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-zinc-200 text-sm text-zinc-600">
+                {users.map((user) => {
+                  const lastAccess = user.lastAccessAt
+                    ? new Date(user.lastAccessAt).toLocaleString("pt-BR", {
+                        day: "2-digit",
+                        month: "2-digit",
+                        year: "numeric",
+                        hour: "2-digit",
+                        minute: "2-digit"
+                      })
+                    : "Nunca";
+
+                  return (
+                    <tr key={user.id} className="hover:bg-zinc-50">
+                      <td className="px-4 py-3 font-medium text-zinc-900">{user.name}</td>
+                      <td className="px-4 py-3">{user.email}</td>
+                      <td className="px-4 py-3 capitalize">{user.profile ?? "-"}</td>
+                      <td className="px-4 py-3">
+                        {user.responsibilities.length > 0 ? (
+                          <div className="flex flex-wrap gap-1">
+                            {user.responsibilities.map((responsibility) => (
+                              <span
+                                key={responsibility}
+                                className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs font-medium text-zinc-500"
+                              >
+                                {responsibility}
+                              </span>
+                            ))}
+                          </div>
+                        ) : (
+                          <span className="text-xs uppercase tracking-wide text-zinc-400">Sem responsabilidades</span>
+                        )}
+                      </td>
+                      <td className="px-4 py-3">
+                        <span
+                          className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-semibold ${
+                            user.status === "active"
+                              ? "bg-emerald-100 text-emerald-700"
+                              : user.status === "blocked"
+                                ? "bg-red-100 text-red-700"
+                                : "bg-amber-100 text-amber-700"
+                          }`}
+                        >
+                          {statusLabels[user.status]}
+                        </span>
+                      </td>
+                      <td className="px-4 py-3 text-xs text-zinc-500">{lastAccess}</td>
+                    </tr>
+                  );
+                })}
+              </tbody>
+            </table>
+            {users.length === 0 && (
+              <div className="px-4 py-6 text-center text-sm text-zinc-500">Nenhum usuário encontrado.</div>
+            )}
+          </section>
+        </>
+      )}
+    </main>
+  );
+}


### PR DESCRIPTION
## Summary
- extend the protected navigation with entries for notifications, user maintenance, and history
- add protected Next.js pages that fetch data for the new sections
- expose stubbed NestJS modules to serve notifications, user maintenance, and history data

## Testing
- pnpm lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68dff719795c83258ec4f803a0e10fc1