### PR TITLE
Add partner notes migration and capture review findings

### DIFF
--- a/mdm-platform/apps/api/src/database/migrations/1700000006000-create-partner-notes.ts
+++ b/mdm-platform/apps/api/src/database/migrations/1700000006000-create-partner-notes.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class CreatePartnerNotes1700000006000 implements MigrationInterface {
+  name = "CreatePartnerNotes1700000006000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE IF NOT EXISTS partner_notes (
+        id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+        partner_id uuid NOT NULL REFERENCES business_partners(id) ON DELETE CASCADE,
+        content text NOT NULL,
+        created_by_id uuid NULL,
+        created_by_name varchar(255) NULL,
+        created_at timestamptz NOT NULL DEFAULT now()
+      );
+    `);
+
+    await queryRunner.query(`
+      CREATE INDEX IF NOT EXISTS idx_partner_notes_partner_id_created_at
+        ON partner_notes (partner_id, created_at DESC);
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      DROP INDEX IF EXISTS idx_partner_notes_partner_id_created_at;
+    `);
+
+    await queryRunner.query(`
+      DROP TABLE IF EXISTS partner_notes;
+    `);
+  }
+}

--- a/mdm-platform/docs/review-findings.md
+++ b/mdm-platform/docs/review-findings.md
@@ -1,0 +1,13 @@
+# Revisão funcional - integração parceiros
+
+## Correção imediata aplicada
+- Criada a migração `1700000006000-create-partner-notes.ts` para materializar a tabela `partner_notes`, evitando falhas ao listar detalhes de parceiros após a adição do módulo de notas. Antes disso, qualquer chamada a `/partners/:id/details` ou `/partners/:id/notes` quebrava por ausência da tabela. ✅
+
+## Pontos que permanecem em aberto
+1. **Documentação desatualizada:** `docs/api-contracts.md` ainda não cita os novos endpoints de notas (`GET/POST /partners/:id/notes`), notificações (`GET /notifications`), manutenção de usuários (`GET /user-maintenance`) e histórico (`GET /history`). Quem consulta apenas o contrato oficial não enxerga essas rotas.
+2. **Módulos auxiliares com dados mockados:** os serviços de notificações, manutenção de usuários e histórico retornam dados estáticos em memória. Para um piloto controlado pode bastar, mas precisamos definir se haverá persistência (PostgreSQL) ou integração com fontes externas antes de liberar testes com usuários reais.
+3. **Cobertura de testes para notas:** não há testes garantindo o fluxo de criação/listagem de notas tanto na API quanto no front-end. Recomendo criar cenários unitários para `PartnersService.createNote`/`listNotes` e um teste de integração rápido exercendo o endpoint protegido por JWT.
+
+## Recomendações próximas
+- Atualizar o guia de contratos e README com as rotas recém-adicionadas e fluxos de navegação (notificações, histórico e manutenção de usuários).
+- Planejar migração/seed para popular usuários perfis/permissões reais, evitando depender dos mocks existentes nas novas telas.


### PR DESCRIPTION
## Summary
- add a TypeORM migration to materialize the partner_notes table with an index so the new notes feature works end-to-end
- capture the QA review findings and outstanding follow-ups in docs/review-findings.md

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68df01b55f7c8325b80fe5a7df0f439c