### PR TITLE
Fix state registration validator default message handling

### DIFF
--- a/mdm-platform/apps/api/src/common/validators/document.validators.ts
+++ b/mdm-platform/apps/api/src/common/validators/document.validators.ts
@@ -82,7 +82,19 @@ export const IsStateRegistration = (options?: StateRegistrationOptions) => {
           if (isEmpty(value)) return true;
           return validateIE(String(value), { allowIsento: options?.allowIsento });
         },
-        defaultMessage: () => options?.message ?? "Inscrição estadual inválida"
+        defaultMessage: (args: ValidationArguments) => {
+          const message = options?.message;
+
+          if (typeof message === "function") {
+            return message(args);
+          }
+
+          if (typeof message === "string") {
+            return message;
+          }
+
+          return "Inscrição estadual inválida";
+        }
       }
     });
   };


### PR DESCRIPTION
## Summary
- ensure the state registration validator always returns a string message
- invoke functional validation messages with their arguments and retain the existing fallback text

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e04f3537688325a25225f8d9e672a7