### PR TITLE
fix(partners): align partner tests with service dependencies

### DIFF
--- a/mdm-platform/apps/api/src/modules/partners/__tests__/audit-logs.spec.ts
+++ b/mdm-platform/apps/api/src/modules/partners/__tests__/audit-logs.spec.ts
@@ -1,13 +1,12 @@
 import "reflect-metadata";
 import { PartnerAuditDifference } from "@mdm/types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PartnersService } from "../partners.service";
 
 vi.mock("../entities/partner.entity", () => ({ Partner: class {} }));
 vi.mock("../entities/partner-change-request.entity", () => ({ PartnerChangeRequest: class {} }));
 vi.mock("../entities/partner-audit-job.entity", () => ({ PartnerAuditJob: class {} }));
 vi.mock("../entities/partner-audit-log.entity", () => ({ PartnerAuditLog: class {} }));
-
-const { PartnersService } = await import("../partners.service");
 
 describe("PartnersService audit processing", () => {
   const repo = {
@@ -23,6 +22,11 @@ describe("PartnersService audit processing", () => {
     update: vi.fn()
   };
   const auditLogRepo = {
+    save: vi.fn()
+  };
+  const noteRepo = {
+    find: vi.fn(),
+    create: vi.fn(),
     save: vi.fn()
   };
   const sapIntegration = {
@@ -42,6 +46,9 @@ describe("PartnersService audit processing", () => {
     auditJobRepo.findOne.mockReset();
     auditJobRepo.update.mockReset();
     auditLogRepo.save.mockReset();
+    noteRepo.find.mockReset();
+    noteRepo.create.mockReset();
+    noteRepo.save.mockReset();
 
     sapIntegration.integratePartner.mockReset();
     sapIntegration.retry.mockReset();
@@ -52,6 +59,7 @@ describe("PartnersService audit processing", () => {
       changeRepo as any,
       auditJobRepo as any,
       auditLogRepo as any,
+      noteRepo as any,
       sapIntegration as any
     );
   });

--- a/mdm-platform/apps/api/src/modules/partners/__tests__/document-validation.spec.ts
+++ b/mdm-platform/apps/api/src/modules/partners/__tests__/document-validation.spec.ts
@@ -3,14 +3,13 @@ import { plainToInstance } from "class-transformer";
 import { validate } from "class-validator";
 import { describe, expect, it, vi, beforeEach } from "vitest";
 import { BadRequestException } from "@nestjs/common";
+import { CreatePartnerDto } from "../dto/create-partner.dto";
+import { PartnersService } from "../partners.service";
 
 vi.mock("../entities/partner.entity", () => ({ Partner: class {} }));
 vi.mock("../entities/partner-change-request.entity", () => ({ PartnerChangeRequest: class {} }));
 vi.mock("../entities/partner-audit-job.entity", () => ({ PartnerAuditJob: class {} }));
 vi.mock("../entities/partner-audit-log.entity", () => ({ PartnerAuditLog: class {} }));
-
-const { CreatePartnerDto } = await import("../dto/create-partner.dto");
-const { PartnersService } = await import("../partners.service");
 
 const basePayload = {
   tipo_pessoa: "PJ" as const,
@@ -84,17 +83,21 @@ describe("PartnersService lookup", () => {
   const changeRepo = { find: vi.fn(), save: vi.fn() };
   const auditJobRepo = { findOne: vi.fn(), update: vi.fn() };
   const auditLogRepo = { save: vi.fn() };
+  const noteRepo = { find: vi.fn(), create: vi.fn(), save: vi.fn() };
   const sapIntegration = {
     integratePartner: vi.fn().mockResolvedValue({ segments: [], completed: true, updates: {} }),
     retry: vi.fn().mockResolvedValue({ segments: [], completed: true, updates: {} }),
     markSegmentsAsError: vi.fn().mockReturnValue([])
   };
 
-  let service: PartnersService;
+  let service: InstanceType<typeof PartnersService>;
 
   beforeEach(() => {
     vi.restoreAllMocks();
     repo.findOne.mockReset();
+    noteRepo.find.mockReset();
+    noteRepo.create.mockReset();
+    noteRepo.save.mockReset();
     sapIntegration.integratePartner.mockReset();
     sapIntegration.retry.mockReset();
     sapIntegration.markSegmentsAsError.mockClear();
@@ -103,6 +106,7 @@ describe("PartnersService lookup", () => {
       changeRepo as any,
       auditJobRepo as any,
       auditLogRepo as any,
+      noteRepo as any,
       sapIntegration as any
     );
   });


### PR DESCRIPTION
## Summary
- replace top-level awaits in partner service specs with static imports
- mock the partner note repository and type the service instances to match the service constructor
- ensure the updated tests compile under TypeScript

## Testing
- pnpm dev
- pnpm test

------
https://chatgpt.com/codex/tasks/task_e_68e05019287c8325816b76a007f443bc