### PR TITLE
Fix SAP partner email filter narrowing

### DIFF
--- a/mdm-platform/apps/api/src/modules/partners/sap-sync.mapper.ts
+++ b/mdm-platform/apps/api/src/modules/partners/sap-sync.mapper.ts
@@ -78,7 +78,10 @@ const sanitizeEmails = (
           if (!address) return null;
           return { endereco: address, padrao: Boolean(email?.default ?? false) };
         })
-        .filter((item): item is { endereco: string; padrao?: boolean } => Boolean(item))
+        .filter(
+          (item): item is { endereco: string; padrao: boolean } =>
+            Boolean(item && typeof item.padrao === "boolean")
+        )
     : undefined;
 
   const normalized: Partner["comunicacao"] = {};


### PR DESCRIPTION
## Summary
- ensure the SAP partner email sanitizer only retains entries with a boolean `padrao`

## Testing
- pnpm build *(fails: missing express and rollup/parseAst type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_68e050ff838c8325adb96c8c9494bf21