### PR TITLE
chore(api): align tsconfig module resolution

### DIFF
--- a/mdm-platform/apps/api/tsconfig.json
+++ b/mdm-platform/apps/api/tsconfig.json
@@ -6,10 +6,11 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "allowSyntheticDefaultImports": true,
-    "target": "es2019",
+    "target": "ES2020",
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
+    "moduleResolution": "node16",
     "paths": {
       "@mdm/types": [
         "../../packages/types/src"


### PR DESCRIPTION
## Summary
- set the API tsconfig to target ES2020 and resolve modules with the node16 strategy to match the workspace configuration

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68e052c822f483258b57a606cf60ff28