### PR TITLE
chore(api): use Node16 module system

### DIFF
--- a/mdm-platform/apps/api/tsconfig.json
+++ b/mdm-platform/apps/api/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "module": "commonjs",
+    "module": "Node16",
     "declaration": true,
     "removeComments": true,
     "emitDecoratorMetadata": true,


### PR DESCRIPTION
## Summary
- update the API tsconfig to compile modules using the Node16 module target

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68e054bb6d2c8325801c0590890cad42