### PR TITLE
Normalize state registration validator message coercion

### DIFF
--- a/mdm-platform/apps/api/src/common/validators/document.validators.ts
+++ b/mdm-platform/apps/api/src/common/validators/document.validators.ts
@@ -82,15 +82,15 @@ export const IsStateRegistration = (options?: StateRegistrationOptions) => {
           if (isEmpty(value)) return true;
           return validateIE(String(value), { allowIsento: options?.allowIsento });
         },
-        defaultMessage: (args: ValidationArguments) => {
+        defaultMessage(args: ValidationArguments) {
           const message = options?.message;
 
           if (typeof message === "function") {
             return message(args);
           }
 
-          if (typeof message === "string") {
-            return message;
+          if (message !== undefined && message !== null) {
+            return String(message);
           }
 
           return "Inscrição estadual inválida";


### PR DESCRIPTION
## Summary
- ensure the state registration validator defaultMessage always returns a string when custom messages are provided
- retain the fallback message when no custom message is supplied

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e058604a688325a866c1463e1bd021