### PR TITLE
fix: remove dynamic import from sap sync spec

### DIFF
--- a/mdm-platform/apps/api/src/modules/partners/__tests__/sap-sync.service.spec.ts
+++ b/mdm-platform/apps/api/src/modules/partners/__tests__/sap-sync.service.spec.ts
@@ -1,15 +1,10 @@
 import "reflect-metadata";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { SapSyncService } from "../sap-sync.service";
 
 vi.mock("../entities/partner.entity", () => ({ Partner: class Partner {} }));
 vi.mock("../entities/partner-audit-log.entity", () => ({ PartnerAuditLog: class PartnerAuditLog {} }));
 vi.mock("../entities/partner-audit-job.entity", () => ({ PartnerAuditJob: class PartnerAuditJob {} }));
-
-let SapSyncService: typeof import("../sap-sync.service").SapSyncService;
-
-beforeAll(async () => {
-  ({ SapSyncService } = await import("../sap-sync.service"));
-});
 
 const originalEnv = {
   SAP_BASE_URL: process.env.SAP_BASE_URL,


### PR DESCRIPTION
## Summary
- replace the sap sync service spec's dynamic import with a standard import so the test file has no top-level await

## Testing
- pnpm vitest run apps/api/src/modules/partners/__tests__/sap-sync.service.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e058c059248325875fa95001fc40c7