### PR TITLE
Ensure SAP sync email filter preserves default flag

### DIFF
--- a/mdm-platform/apps/api/src/modules/partners/__tests__/sap-sync.mapper.spec.ts
+++ b/mdm-platform/apps/api/src/modules/partners/__tests__/sap-sync.mapper.spec.ts
@@ -50,6 +50,27 @@ describe("mapSapPartnerPayload", () => {
     expect(result.transportadores).toEqual([{ sap_bp: "T1" }]);
   });
 
+  it("normalizes communication emails keeping default flags", () => {
+    const payload = {
+      communication: {
+        emails: [
+          { address: "primary@example.com", default: true },
+          { address: "secondary@example.com" },
+          { address: "", default: true },
+          { address: "tertiary@example.com", default: false }
+        ]
+      }
+    };
+
+    const result = mapSapPartnerPayload(payload as any);
+
+    expect(result.comunicacao?.emails).toEqual([
+      { endereco: "primary@example.com", padrao: true },
+      { endereco: "secondary@example.com", padrao: false },
+      { endereco: "tertiary@example.com", padrao: false }
+    ]);
+  });
+
   it("normalizes segments removing invalid entries", () => {
     const payload = {
       sapSegments: [

--- a/mdm-platform/apps/api/src/modules/partners/sap-sync.mapper.ts
+++ b/mdm-platform/apps/api/src/modules/partners/sap-sync.mapper.ts
@@ -78,10 +78,7 @@ const sanitizeEmails = (
           if (!address) return null;
           return { endereco: address, padrao: Boolean(email?.default ?? false) };
         })
-        .filter(
-          (item): item is { endereco: string; padrao: boolean } =>
-            Boolean(item && typeof item.padrao === "boolean")
-        )
+        .filter((item): item is { endereco: string; padrao: boolean } => item !== null)
     : undefined;
 
   const normalized: Partner["comunicacao"] = {};


### PR DESCRIPTION
## Summary
- simplify the communication email sanitizer to exclude only null entries while keeping the default flag set
- add coverage for mixed SAP email inputs to confirm default flags are preserved

## Testing
- pnpm vitest run apps/api/src/modules/partners/__tests__/sap-sync.mapper.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e06154d4f08325ab4d60124ec648ed