### PR TITLE
chore(api): add express runtime dependency

### DIFF
--- a/mdm-platform/apps/api/package.json
+++ b/mdm-platform/apps/api/package.json
@@ -23,6 +23,7 @@
     "bcryptjs": "^2.4.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
+    "express": "^4.19.2",
     "pg": "^8.11.3",
     "passport": "^0.7.0",
     "passport-jwt": "^4.0.1",

--- a/mdm-platform/pnpm-lock.yaml
+++ b/mdm-platform/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       class-validator:
         specifier: ^0.14.0
         version: 0.14.2
+      express:
+        specifier: ^4.19.2
+        version: 4.21.2
       passport:
         specifier: ^0.7.0
         version: 0.7.0


### PR DESCRIPTION
## Summary
- add the express runtime dependency to the API workspace so the existing type package has a matching implementation
- refresh the workspace lockfile via pnpm install

## Testing
- pnpm install
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68e0626324e883259cac839ea4b3c39b