### PR TITLE
Align API tsconfig with Node16 module resolution

### DIFF
--- a/mdm-platform/apps/api/tsconfig.json
+++ b/mdm-platform/apps/api/tsconfig.json
@@ -10,7 +10,7 @@
     "sourceMap": true,
     "outDir": "./dist",
     "baseUrl": "./",
-    "moduleResolution": "node16",
+    "moduleResolution": "Node16",
     "paths": {
       "@mdm/types": [
         "../../packages/types/src"


### PR DESCRIPTION
## Summary
- set the API TypeScript config to use the Node16 module resolver to match the module setting

## Testing
- pnpm dev

------
https://chatgpt.com/codex/tasks/task_e_68e0633d75048325b5cd4a511a16c8ec