### PR TITLE
Ensure state registration validator default message coerces to string

### DIFF
--- a/mdm-platform/apps/api/src/common/validators/document.validators.ts
+++ b/mdm-platform/apps/api/src/common/validators/document.validators.ts
@@ -86,14 +86,10 @@ export const IsStateRegistration = (options?: StateRegistrationOptions) => {
           const message = options?.message;
 
           if (typeof message === "function") {
-            return message(args);
+            return String(message(args));
           }
 
-          if (message !== undefined && message !== null) {
-            return String(message);
-          }
-
-          return "Inscrição estadual inválida";
+          return String(message ?? "Inscrição estadual inválida");
         }
       }
     });


### PR DESCRIPTION
## Summary
- coerce custom message callbacks to strings in the state registration validator
- default to the fallback "Inscrição estadual inválida" string when no custom message is provided

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e06564a40c83259bb6faa80187da36