### PR TITLE
test: mock PartnerNote in partners service specs

### DIFF
--- a/mdm-platform/apps/api/src/modules/partners/__tests__/audit-logs.spec.ts
+++ b/mdm-platform/apps/api/src/modules/partners/__tests__/audit-logs.spec.ts
@@ -7,6 +7,7 @@ vi.mock("../entities/partner.entity", () => ({ Partner: class {} }));
 vi.mock("../entities/partner-change-request.entity", () => ({ PartnerChangeRequest: class {} }));
 vi.mock("../entities/partner-audit-job.entity", () => ({ PartnerAuditJob: class {} }));
 vi.mock("../entities/partner-audit-log.entity", () => ({ PartnerAuditLog: class {} }));
+vi.mock("../entities/partner-note.entity", () => ({ PartnerNote: class {} }));
 
 describe("PartnersService audit processing", () => {
   const repo = {

--- a/mdm-platform/apps/api/src/modules/partners/__tests__/document-validation.spec.ts
+++ b/mdm-platform/apps/api/src/modules/partners/__tests__/document-validation.spec.ts
@@ -10,6 +10,7 @@ vi.mock("../entities/partner.entity", () => ({ Partner: class {} }));
 vi.mock("../entities/partner-change-request.entity", () => ({ PartnerChangeRequest: class {} }));
 vi.mock("../entities/partner-audit-job.entity", () => ({ PartnerAuditJob: class {} }));
 vi.mock("../entities/partner-audit-log.entity", () => ({ PartnerAuditLog: class {} }));
+vi.mock("../entities/partner-note.entity", () => ({ PartnerNote: class {} }));
 
 const basePayload = {
   tipo_pessoa: "PJ" as const,


### PR DESCRIPTION
## Summary
- add PartnerNote entity mocks to the partners service audit log and document validation specs so the static PartnersService import can resolve cleanly

## Testing
- pnpm --filter @mdm/api test -- src/modules/partners/__tests__/audit-logs.spec.ts src/modules/partners/__tests__/document-validation.spec.ts

------
https://chatgpt.com/codex/tasks/task_e_68e065fa59e88325b187b46ba919aa55