### PR TITLE
chore(api): add express types to runtime deps

### DIFF
--- a/mdm-platform/apps/api/package.json
+++ b/mdm-platform/apps/api/package.json
@@ -20,6 +20,7 @@
     "@nestjs/schedule": "^3.0.1",
     "@nestjs/swagger": "^7.0.0",
     "@nestjs/typeorm": "^10.0.0",
+    "@types/express": "^4.17.21",
     "bcryptjs": "^2.4.3",
     "class-transformer": "^0.5.1",
     "class-validator": "^0.14.0",
@@ -35,7 +36,6 @@
   },
   "devDependencies": {
     "@nestjs/cli": "^10.4.9",
-    "@types/express": "^4.17.21",
     "@types/node": "^20.12.8",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",

--- a/mdm-platform/pnpm-lock.yaml
+++ b/mdm-platform/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@nestjs/typeorm':
         specifier: ^10.0.0
         version: 10.0.2(@nestjs/common@10.4.20(class-transformer@0.5.1)(class-validator@0.14.2)(reflect-metadata@0.1.14)(rxjs@7.8.2))(@nestjs/core@10.4.20)(reflect-metadata@0.1.14)(rxjs@7.8.2)(typeorm@0.3.27(pg@8.16.3)(reflect-metadata@0.1.14)(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2)))
+      '@types/express':
+        specifier: ^4.17.21
+        version: 4.17.23
       bcryptjs:
         specifier: ^2.4.3
         version: 2.4.3
@@ -87,9 +90,6 @@ importers:
       '@nestjs/cli':
         specifier: ^10.4.9
         version: 10.4.9
-      '@types/express':
-        specifier: ^4.17.21
-        version: 4.17.23
       '@types/node':
         specifier: ^20.12.8
         version: 20.19.17


### PR DESCRIPTION
## Summary
- move `@types/express` into the API application's runtime dependency list so TypeScript can resolve Request
- refresh the workspace lockfile to capture the dependency location change

## Testing
- pnpm install
- pnpm exec ts-node --compiler-options '{"module":"commonjs","types":["node","express"],"esModuleInterop":true}' --skip-project -e "import { Request } from 'express'; const req: Request = {} as any; console.log('ok');"


------
https://chatgpt.com/codex/tasks/task_e_68e065feb614832592eae5c53c045c39