### PR TITLE
fix: prevent API build failures caused by missing express typings

### DIFF
--- a/mdm-platform/apps/api/src/modules/partners/partners.controller.ts
+++ b/mdm-platform/apps/api/src/modules/partners/partners.controller.ts
@@ -1,7 +1,6 @@
 import { Body, Controller, Get, Param, Post, Query, Req, UseGuards } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { AuthGuard } from "@nestjs/passport";
-import { Request } from "express";
 import { CreatePartnerDto } from "./dto/create-partner.dto";
 import { ChangeRequestListQueryDto, CreateBulkChangeRequestDto, CreateChangeRequestDto } from "./dto/change-request.dto";
 import { AuthenticatedUser, PartnersService } from "./partners.service";
@@ -21,7 +20,7 @@ class StageDecisionDto {
   motivo?: string;
 }
 
-type AuthenticatedRequest = Request & { user: AuthenticatedUser };
+type AuthenticatedRequest = { user: AuthenticatedUser };
 
 @ApiTags("partners")
 @ApiBearerAuth()

--- a/mdm-platform/apps/api/tsconfig.json
+++ b/mdm-platform/apps/api/tsconfig.json
@@ -11,6 +11,7 @@
     "outDir": "./dist",
     "baseUrl": "./",
     "moduleResolution": "Node16",
+    "types": ["node"],
     "paths": {
       "@mdm/types": [
         "../../packages/types/src"
@@ -19,5 +20,11 @@
   },
   "include": [
     "src/**/*"
+  ],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
   ]
 }


### PR DESCRIPTION
## Summary
- stop depending on Express typings in the partners controller when only the authenticated user is needed
- restrict the API TypeScript config to node types and exclude spec files from the build to avoid Vitest ESM resolution errors

## Testing
- pnpm --filter @mdm/api build

------
https://chatgpt.com/codex/tasks/task_e_68e068265b2083258b42d8e720cfe772