### PR TITLE
fix(api): compile workspace types package

### DIFF
--- a/mdm-platform/apps/api/package.json
+++ b/mdm-platform/apps/api/package.json
@@ -2,7 +2,9 @@
   "name": "@mdm/api",
   "private": true,
   "scripts": {
+    "predev": "pnpm --filter @mdm/types build",
     "dev": "nest start --watch",
+    "prebuild": "pnpm --filter @mdm/types build",
     "build": "nest build",
     "start:prod": "node dist/main.js",
     "migration:run": "ts-node --project tsconfig.json ./node_modules/typeorm/cli.js migration:run -d src/database/ormconfig.ts",

--- a/mdm-platform/apps/api/tsconfig.json
+++ b/mdm-platform/apps/api/tsconfig.json
@@ -9,12 +9,16 @@
     "target": "ES2020",
     "sourceMap": true,
     "outDir": "./dist",
+    "rootDir": "./src",
     "baseUrl": "./",
     "moduleResolution": "Node16",
     "types": ["node"],
     "paths": {
       "@mdm/types": [
-        "../../packages/types/src"
+        "../../packages/types/dist/index"
+      ],
+      "@mdm/types/*": [
+        "../../packages/types/dist/*"
       ]
     }
   },

--- a/mdm-platform/packages/types/package.json
+++ b/mdm-platform/packages/types/package.json
@@ -2,8 +2,12 @@
   "name": "@mdm/types",
   "version": "0.0.1",
   "private": true,
-  "main": "src/index.ts",
-  "types": "src/index.ts",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc --project tsconfig.json",
+    "dev": "tsc --project tsconfig.json --watch --preserveWatchOutput"
+  },
   "dependencies": {
     "zod": "^3.23.8"
   }

--- a/mdm-platform/packages/types/tsconfig.json
+++ b/mdm-platform/packages/types/tsconfig.json
@@ -1,1 +1,22 @@
-{ "extends": "../../tsconfig.base.json", "compilerOptions": { "outDir": "dist" }, "include": ["src"] }
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "Node16",
+    "target": "ES2020",
+    "declaration": true,
+    "emitDeclarationOnly": false,
+    "outDir": "dist",
+    "rootDir": "src",
+    "moduleResolution": "Node16",
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "sourceMap": true
+  },
+  "include": ["src/**/*"],
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/**/*.spec.tsx",
+    "src/**/*.test.ts",
+    "src/**/*.test.tsx"
+  ]
+}

--- a/mdm-platform/turbo.json
+++ b/mdm-platform/turbo.json
@@ -2,7 +2,7 @@
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
     "build": { "dependsOn": ["^build"], "outputs": ["dist/**", ".next/**"] },
-    "dev": { "cache": false, "persistent": true },
+    "dev": { "cache": false, "persistent": true, "dependsOn": ["^dev"] },
     "lint": {},
     "test": {}
   }


### PR DESCRIPTION
## Summary
- emit the @mdm/types package to dist with build/dev scripts so other apps can consume compiled outputs
- point the API tsconfig paths at the built type artifacts and ensure its dev/build scripts prebuild the package
- make turbo dev tasks depend on dependency dev tasks for consistent watch behavior

## Testing
- pnpm --filter @mdm/api dev

------
https://chatgpt.com/codex/tasks/task_e_68e06b17df50832598ab70fa523c0dd8