### PR TITLE
Fix AddressSchema default chaining style

### DIFF
--- a/mdm-platform/packages/types/src/partner.ts
+++ b/mdm-platform/packages/types/src/partner.ts
@@ -33,8 +33,7 @@ export const PartnerApprovalHistoryEntrySchema = z.object({
 });
 
 export const AddressSchema = z.object({
-  tipo: z.enum(["fiscal", "cobranca", "entrega"]).
-    default("fiscal"),
+  tipo: z.enum(["fiscal", "cobranca", "entrega"]).default("fiscal"),
   cep: z.string(),
   logradouro: z.string(),
   numero: z.string(),


### PR DESCRIPTION
## Summary
- adjust the AddressSchema `tipo` field chaining so `.default` remains on the same line as the enum

## Testing
- pnpm --filter @mdm/types build

------
https://chatgpt.com/codex/tasks/task_e_68e078a57d388325aa456360d339ac94