### PR TITLE
fix: stop dev task dependency cycle

### DIFF
--- a/mdm-platform/turbo.json
+++ b/mdm-platform/turbo.json
@@ -1,10 +1,20 @@
-﻿{
+{
   "$schema": "https://turbo.build/schema.json",
   "tasks": {
-    "build": { "dependsOn": ["^build"], "outputs": ["dist/**", ".next/**"] },
-    "dev": { "cache": false, "persistent": true, "dependsOn": ["^dev"] },
+    "build": {
+      "dependsOn": [
+        "^build"
+      ],
+      "outputs": [
+        "dist/**",
+        ".next/**"
+      ]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
     "lint": {},
     "test": {}
   }
 }
-


### PR DESCRIPTION
## Summary
- remove the `dev` task's dependency on `^dev` to avoid pointing at another persistent task

## Testing
- pnpm dev *(fails: interrupted after verifying the task started successfully)*

------
https://chatgpt.com/codex/tasks/task_e_68e07aa068a08325911c66527d2a15ce