### PR TITLE
chore: lock turbo ui to stream

### DIFF
--- a/mdm-platform/turbo.json
+++ b/mdm-platform/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "ui": "stream",
   "tasks": {
     "build": {
       "dependsOn": [


### PR DESCRIPTION
## Summary
- set the Turbo UI to the stream logger to avoid console encoding issues on Windows

## Testing
- pnpm test *(fails: @mdm/api test suite currently errors because @mdm/types cannot be resolved)*

------
https://chatgpt.com/codex/tasks/task_e_68e083b6c01483259ceea6b379982599