### PR TITLE
Add timestamps to business partners

### DIFF
--- a/mdm-platform/apps/api/src/database/migrations/1700000007000-add-partner-timestamps.ts
+++ b/mdm-platform/apps/api/src/database/migrations/1700000007000-add-partner-timestamps.ts
@@ -1,0 +1,33 @@
+import { MigrationInterface, QueryRunner } from "typeorm";
+
+export class AddPartnerTimestamps1700000007000 implements MigrationInterface {
+  name = "AddPartnerTimestamps1700000007000";
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE business_partners
+        ADD COLUMN IF NOT EXISTS created_at timestamptz DEFAULT now(),
+        ADD COLUMN IF NOT EXISTS updated_at timestamptz DEFAULT now();
+    `);
+
+    await queryRunner.query(`
+      UPDATE business_partners
+      SET created_at = COALESCE(created_at, now()),
+          updated_at = COALESCE(updated_at, now());
+    `);
+
+    await queryRunner.query(`
+      ALTER TABLE business_partners
+        ALTER COLUMN created_at SET NOT NULL,
+        ALTER COLUMN updated_at SET NOT NULL;
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      ALTER TABLE business_partners
+        DROP COLUMN IF EXISTS created_at,
+        DROP COLUMN IF EXISTS updated_at;
+    `);
+  }
+}


### PR DESCRIPTION
## Summary
- add a migration that introduces created_at and updated_at columns to business_partners
- backfill existing rows and enforce NOT NULL constraints for the new timestamp columns

## Testing
- `pnpm --filter @mdm/api migration:run` *(fails: cannot connect to postgres on localhost:5432 in container)*
- `pnpm --filter @mdm/api test` *(fails: missing workspace packages @mdm/types and @mdm/utils when running vitest)*

------
https://chatgpt.com/codex/tasks/task_e_68e197073e4c8325a49052c8ab9ca55a