### PR TITLE
Update CNPJA integration endpoint

### DIFF
--- a/mdm-platform/apps/api/.env.example
+++ b/mdm-platform/apps/api/.env.example
@@ -4,6 +4,6 @@ DATABASE_URL=postgres://mdm:mdm@db:5432/mdm
 JWT_SECRET=your-jwt-secret
 TURNSTILE_SECRET_KEY=your-turnstile-secret
 CNPJ_API_URL=https://publica.cnpj.ws/cnpj
-CNPJ_OPEN_API_URL=https://cnpja.com/api/open
+CNPJ_OPEN_API_URL=https://api.cnpja.com
 CPF_API_URL=https://api.gov.br/cpf
 CPF_API_TOKEN=your-cpf-api-token

--- a/mdm-platform/apps/api/src/modules/partners/partners.service.ts
+++ b/mdm-platform/apps/api/src/modules/partners/partners.service.ts
@@ -1243,13 +1243,13 @@ export class PartnersService {
   }
 
   private async fetchFromCnpja(cnpj: string) {
-    const baseUrl = process.env.CNPJ_OPEN_API_URL || "https://cnpja.com/api";
+    const baseUrl = process.env.CNPJ_OPEN_API_URL || "https://api.cnpja.com";
     const token = process.env.CNPJ_OPEN_API_TOKEN;
     const headers: Record<string, string> = { Accept: "application/json" };
     if (token) {
       headers.Authorization = `Bearer ${token}`;
     }
-    const response = await fetch(`${baseUrl.replace(/\/$/, "")}/cnpj/${cnpj}`, { headers });
+    const response = await fetch(`${baseUrl.replace(/\/$/, "")}/office/${cnpj}`, { headers });
     if (!response.ok) {
       throw new Error(`cnpja responded with status ${response.status}`);
     }


### PR DESCRIPTION
## Summary
- update the partners service to build the CNPJA request using the /office path
- point the sample CNPJ_OPEN_API_URL configuration to https://api.cnpja.com to match the new endpoint

## Testing
- ⚠️ `curl -s -o /tmp/cnpja.json -w '%{http_code}\n' https://api.cnpja.com/office/27865757000102` *(fails with 401 because the public endpoint requires authentication tokens in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e19a7366a08325bb2cf88f305b8a74