### PR TITLE
Require CNPJa token configuration for partner fetches

### DIFF
--- a/mdm-platform/README.md
+++ b/mdm-platform/README.md
@@ -35,6 +35,7 @@ Monorepo com **Next.js (web)** + **NestJS (api)** + **PostgreSQL** + **Docker co
    ```
    - Ajuste `DATABASE_URL` para apontar ao PostgreSQL local (ex.: `postgres://mdm:mdm@localhost:5432/mdm`).
    - Defina `JWT_SECRET`, credenciais do Turnstile (`NEXT_PUBLIC_TURNSTILE_SITE_KEY`) e variáveis SAP conforme necessidade.
+   - Informe `CNPJ_OPEN_API_TOKEN` em `apps/api/.env.local` com o token emitido pela CNPJa para habilitar as consultas externas.
 4. **Subir banco de dados e pgAdmin**
    ```bash
    pnpm db:up

--- a/mdm-platform/apps/api/.env.example
+++ b/mdm-platform/apps/api/.env.example
@@ -5,5 +5,6 @@ JWT_SECRET=your-jwt-secret
 TURNSTILE_SECRET_KEY=your-turnstile-secret
 CNPJ_API_URL=https://publica.cnpj.ws/cnpj
 CNPJ_OPEN_API_URL=https://api.cnpja.com
+CNPJ_OPEN_API_TOKEN=seu-token-da-cnpja
 CPF_API_URL=https://api.gov.br/cpf
 CPF_API_TOKEN=your-cpf-api-token

--- a/mdm-platform/apps/api/src/modules/partners/partners.service.ts
+++ b/mdm-platform/apps/api/src/modules/partners/partners.service.ts
@@ -1245,10 +1245,15 @@ export class PartnersService {
   private async fetchFromCnpja(cnpj: string) {
     const baseUrl = process.env.CNPJ_OPEN_API_URL || "https://api.cnpja.com";
     const token = process.env.CNPJ_OPEN_API_TOKEN;
-    const headers: Record<string, string> = { Accept: "application/json" };
-    if (token) {
-      headers.Authorization = `Bearer ${token}`;
+    if (!token) {
+      throw new InternalServerErrorException(
+        "Variável de ambiente CNPJ_OPEN_API_TOKEN não está configurada para chamadas à CNPJa."
+      );
     }
+    const headers: Record<string, string> = {
+      Accept: "application/json",
+      Authorization: `Bearer ${token}`
+    };
     const response = await fetch(`${baseUrl.replace(/\/$/, "")}/office/${cnpj}`, { headers });
     if (!response.ok) {
       throw new Error(`cnpja responded with status ${response.status}`);


### PR DESCRIPTION
## Summary
- document the required `CNPJ_OPEN_API_TOKEN` variable in the API environment example
- guard `fetchFromCnpja` against missing credentials to avoid unauthenticated calls
- update the local setup instructions to mention configuring the CNPJa token

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1a72e91ac832589b8fefc8a0dbc7d