### PR TITLE
feat: add user maintenance crud flow

### DIFF
--- a/mdm-platform/apps/api/src/modules/user-maintenance/dto/create-managed-user.dto.ts
+++ b/mdm-platform/apps/api/src/modules/user-maintenance/dto/create-managed-user.dto.ts
@@ -1,0 +1,28 @@
+import { IsArray, IsEmail, IsIn, IsNotEmpty, IsOptional, IsString } from "class-validator";
+
+import { MANAGED_USER_STATUSES, ManagedUserStatus } from "../user-maintenance.types";
+
+export class CreateManagedUserDto {
+  @IsString()
+  @IsNotEmpty()
+  name!: string;
+
+  @IsEmail()
+  email!: string;
+
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  profile: string | null = null;
+
+  @IsArray()
+  @IsString({ each: true })
+  responsibilities!: string[];
+
+  @IsIn(MANAGED_USER_STATUSES)
+  status!: ManagedUserStatus;
+
+  @IsOptional()
+  @IsString()
+  lastAccessAt?: string | null;
+}

--- a/mdm-platform/apps/api/src/modules/user-maintenance/dto/update-managed-user.dto.ts
+++ b/mdm-platform/apps/api/src/modules/user-maintenance/dto/update-managed-user.dto.ts
@@ -1,0 +1,5 @@
+import { PartialType } from "@nestjs/swagger";
+
+import { CreateManagedUserDto } from "./create-managed-user.dto";
+
+export class UpdateManagedUserDto extends PartialType(CreateManagedUserDto) {}

--- a/mdm-platform/apps/api/src/modules/user-maintenance/user-maintenance.controller.ts
+++ b/mdm-platform/apps/api/src/modules/user-maintenance/user-maintenance.controller.ts
@@ -1,8 +1,20 @@
-import { Controller, Get, UseGuards } from "@nestjs/common";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Patch,
+  Post,
+  Put,
+  UseGuards
+} from "@nestjs/common";
 import { ApiBearerAuth, ApiTags } from "@nestjs/swagger";
 import { AuthGuard } from "@nestjs/passport";
 
 import { UserMaintenanceService } from "./user-maintenance.service";
+import { CreateManagedUserDto } from "./dto/create-managed-user.dto";
+import { UpdateManagedUserDto } from "./dto/update-managed-user.dto";
 
 @ApiTags("user-maintenance")
 @ApiBearerAuth()
@@ -14,5 +26,25 @@ export class UserMaintenanceController {
   @Get()
   list() {
     return this.service.list();
+  }
+
+  @Post()
+  create(@Body() body: CreateManagedUserDto) {
+    return this.service.create(body);
+  }
+
+  @Put(":id")
+  replace(@Param("id") id: string, @Body() body: CreateManagedUserDto) {
+    return this.service.replace(id, body);
+  }
+
+  @Patch(":id")
+  update(@Param("id") id: string, @Body() body: UpdateManagedUserDto) {
+    return this.service.update(id, body);
+  }
+
+  @Delete(":id")
+  remove(@Param("id") id: string) {
+    return this.service.remove(id);
   }
 }

--- a/mdm-platform/apps/api/src/modules/user-maintenance/user-maintenance.service.spec.ts
+++ b/mdm-platform/apps/api/src/modules/user-maintenance/user-maintenance.service.spec.ts
@@ -1,0 +1,89 @@
+import { ConflictException, NotFoundException } from "@nestjs/common";
+import { describe, expect, it } from "vitest";
+
+import { UserMaintenanceService } from "./user-maintenance.service";
+import { MANAGED_USER_STATUSES } from "./user-maintenance.types";
+
+const samplePayload = {
+  name: "Novo Usuário",
+  email: "novo.usuario@example.com",
+  profile: "fiscal",
+  responsibilities: ["partners.approval.fiscal"],
+  status: "active" as const
+};
+
+describe("UserMaintenanceService", () => {
+  it("creates a new user and keeps it in memory", () => {
+    const service = new UserMaintenanceService();
+
+    const created = service.create(samplePayload);
+
+    expect(created).toMatchObject({
+      id: expect.any(String),
+      name: "Novo Usuário",
+      email: "novo.usuario@example.com",
+      profile: "fiscal",
+      responsibilities: ["partners.approval.fiscal"],
+      status: "active"
+    });
+
+    const users = service.list();
+    expect(users.some((user) => user.id === created.id)).toBe(true);
+  });
+
+  it("prevents duplicated e-mails", () => {
+    const service = new UserMaintenanceService();
+    const [existing] = service.list();
+
+    expect(() =>
+      service.create({
+        ...samplePayload,
+        email: existing.email
+      })
+    ).toThrow(ConflictException);
+  });
+
+  it("replaces an user information", () => {
+    const service = new UserMaintenanceService();
+    const [existing] = service.list();
+
+    const updated = service.replace(existing.id, {
+      ...samplePayload,
+      email: "updated.email@example.com"
+    });
+
+    expect(updated.email).toBe("updated.email@example.com");
+    expect(updated.name).toBe("Novo Usuário");
+
+    const [persisted] = service.list().filter((user) => user.id === existing.id);
+    expect(persisted?.email).toBe("updated.email@example.com");
+  });
+
+  it("updates partial information including status", () => {
+    const service = new UserMaintenanceService();
+    const [existing] = service.list();
+
+    const newStatus = MANAGED_USER_STATUSES.find((status) => status !== existing.status) ?? "blocked";
+
+    const updated = service.update(existing.id, {
+      status: newStatus,
+      responsibilities: []
+    });
+
+    expect(updated.status).toBe(newStatus);
+    expect(updated.responsibilities).toHaveLength(0);
+  });
+
+  it("removes users and throws if id is unknown", () => {
+    const service = new UserMaintenanceService();
+    const [existing] = service.list();
+
+    const removed = service.remove(existing.id);
+
+    expect(removed.id).toBe(existing.id);
+    expect(service.list().some((user) => user.id === existing.id)).toBe(false);
+
+    expect(() => service.remove("unknown"))
+      .toThrow(NotFoundException);
+  });
+});

--- a/mdm-platform/apps/api/src/modules/user-maintenance/user-maintenance.service.ts
+++ b/mdm-platform/apps/api/src/modules/user-maintenance/user-maintenance.service.ts
@@ -1,14 +1,18 @@
-import { Injectable } from "@nestjs/common";
+import { randomUUID } from "node:crypto";
 
-type ManagedUser = {
-  id: string;
-  name: string;
-  email: string;
-  profile: string | null;
-  responsibilities: string[];
-  status: "active" | "invited" | "blocked";
-  lastAccessAt?: string | null;
-};
+import {
+  ConflictException,
+  Injectable,
+  NotFoundException
+} from "@nestjs/common";
+
+import {
+  MANAGED_USER_STATUSES,
+  ManagedUser,
+  ManagedUserStatus
+} from "./user-maintenance.types";
+import { CreateManagedUserDto } from "./dto/create-managed-user.dto";
+import { UpdateManagedUserDto } from "./dto/update-managed-user.dto";
 
 @Injectable()
 export class UserMaintenanceService {
@@ -52,6 +56,119 @@ export class UserMaintenanceService {
   ];
 
   list(): ManagedUser[] {
-    return this.users;
+    return this.users.map((user) => ({
+      ...user,
+      responsibilities: [...user.responsibilities]
+    }));
+  }
+
+  create(payload: CreateManagedUserDto): ManagedUser {
+    this.ensureEmailIsUnique(payload.email);
+
+    const newUser: ManagedUser = {
+      id: randomUUID(),
+      name: payload.name.trim(),
+      email: payload.email.toLowerCase(),
+      profile: payload.profile?.trim() || null,
+      responsibilities: this.normalizeResponsibilities(payload.responsibilities),
+      status: payload.status,
+      lastAccessAt: payload.lastAccessAt ?? null
+    };
+
+    this.users.push(newUser);
+
+    return { ...newUser, responsibilities: [...newUser.responsibilities] };
+  }
+
+  replace(id: string, payload: CreateManagedUserDto): ManagedUser {
+    const user = this.findById(id);
+    this.ensureEmailIsUnique(payload.email, id);
+
+    user.name = payload.name.trim();
+    user.email = payload.email.toLowerCase();
+    user.profile = payload.profile?.trim() || null;
+    user.responsibilities = this.normalizeResponsibilities(payload.responsibilities);
+    user.status = payload.status;
+    if (payload.lastAccessAt !== undefined) {
+      user.lastAccessAt = payload.lastAccessAt;
+    }
+
+    return { ...user, responsibilities: [...user.responsibilities] };
+  }
+
+  update(id: string, payload: UpdateManagedUserDto): ManagedUser {
+    const user = this.findById(id);
+
+    if (payload.email && payload.email !== user.email) {
+      this.ensureEmailIsUnique(payload.email, id);
+      user.email = payload.email.toLowerCase();
+    }
+
+    if (payload.name) {
+      user.name = payload.name.trim();
+    }
+
+    if (payload.profile !== undefined) {
+      user.profile = payload.profile?.trim() || null;
+    }
+
+    if (payload.responsibilities !== undefined) {
+      user.responsibilities = this.normalizeResponsibilities(payload.responsibilities);
+    }
+
+    if (payload.status) {
+      this.assertValidStatus(payload.status);
+      user.status = payload.status;
+    }
+
+    if (payload.lastAccessAt !== undefined) {
+      user.lastAccessAt = payload.lastAccessAt;
+    }
+
+    return { ...user, responsibilities: [...user.responsibilities] };
+  }
+
+  remove(id: string): ManagedUser {
+    const index = this.users.findIndex((user) => user.id === id);
+
+    if (index === -1) {
+      throw new NotFoundException("Usuário não encontrado.");
+    }
+
+    const [removed] = this.users.splice(index, 1);
+    return { ...removed, responsibilities: [...removed.responsibilities] };
+  }
+
+  private ensureEmailIsUnique(email: string, ignoreId?: string) {
+    const normalized = email.toLowerCase();
+    const conflict = this.users.find(
+      (user) => user.email === normalized && user.id !== ignoreId
+    );
+
+    if (conflict) {
+      throw new ConflictException("Já existe um usuário com este e-mail cadastrado.");
+    }
+  }
+
+  private findById(id: string): ManagedUser {
+    const user = this.users.find((item) => item.id === id);
+
+    if (!user) {
+      throw new NotFoundException("Usuário não encontrado.");
+    }
+
+    return user;
+  }
+
+  private normalizeResponsibilities(responsibilities: string[]): string[] {
+    return responsibilities
+      .map((responsibility) => responsibility.trim())
+      .filter((responsibility) => responsibility.length > 0);
+  }
+
+  private assertValidStatus(status: ManagedUserStatus) {
+    if (!MANAGED_USER_STATUSES.includes(status)) {
+      throw new ConflictException("Status de usuário inválido.");
+    }
   }
 }

--- a/mdm-platform/apps/api/src/modules/user-maintenance/user-maintenance.types.ts
+++ b/mdm-platform/apps/api/src/modules/user-maintenance/user-maintenance.types.ts
@@ -1,0 +1,13 @@
+export const MANAGED_USER_STATUSES = ["active", "invited", "blocked"] as const;
+
+export type ManagedUserStatus = (typeof MANAGED_USER_STATUSES)[number];
+
+export type ManagedUser = {
+  id: string;
+  name: string;
+  email: string;
+  profile: string | null;
+  responsibilities: string[];
+  status: ManagedUserStatus;
+  lastAccessAt?: string | null;
+};

--- a/mdm-platform/apps/web/src/app/(protected)/user-maintenance/__tests__/page.spec.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/user-maintenance/__tests__/page.spec.tsx
@@ -1,0 +1,207 @@
+import React from "react";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import axios from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import UserMaintenancePage from "../page";
+import { getStoredUser } from "../../../../lib/auth";
+
+vi.mock("axios", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn()
+  }
+}));
+
+const routerReplaceMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: routerReplaceMock })
+}));
+
+vi.mock("../../../../lib/auth", () => ({
+  getStoredUser: vi.fn()
+}));
+
+type AxiosMock = {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+};
+
+const axiosMock = axios as unknown as AxiosMock;
+const getStoredUserMock = getStoredUser as unknown as ReturnType<typeof vi.fn>;
+
+const apiBaseUrl = "http://localhost:3333";
+
+describe("UserMaintenancePage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    axiosMock.get.mockReset();
+    axiosMock.post.mockReset();
+    axiosMock.put.mockReset();
+    axiosMock.patch.mockReset();
+    axiosMock.delete.mockReset();
+    routerReplaceMock.mockReset();
+    getStoredUserMock.mockReset();
+    localStorage.clear();
+    localStorage.setItem("mdmToken", "token");
+    process.env.NEXT_PUBLIC_API_URL = apiBaseUrl;
+    getStoredUserMock.mockReturnValue({
+      id: "admin",
+      email: "admin@example.com",
+      responsibilities: ["partners.admin"]
+    });
+    axiosMock.get.mockResolvedValue({ data: [] });
+  });
+
+  it("allows creating a new user and updates the table", async () => {
+    const user = userEvent.setup();
+    const createdUser = {
+      id: "u-100",
+      name: "Maria Souza",
+      email: "maria.souza@example.com",
+      profile: "fiscal",
+      responsibilities: ["partners.approval.fiscal"],
+      status: "active" as const,
+      lastAccessAt: null
+    };
+
+    axiosMock.post.mockResolvedValue({ data: createdUser });
+
+    render(<UserMaintenancePage />);
+
+    await screen.findByText("Nenhum usuário encontrado.");
+
+    await user.click(screen.getByRole("button", { name: /novo usuário/i }));
+
+    await user.type(screen.getByLabelText(/nome/i), "Maria Souza");
+    await user.type(screen.getByLabelText(/e-mail/i), "maria.souza@example.com");
+    await user.type(screen.getByLabelText(/perfil/i), "fiscal");
+    await user.type(screen.getByLabelText(/responsabilidades/i), "partners.approval.fiscal");
+    await user.selectOptions(screen.getByLabelText(/^status$/i), "active");
+
+    await user.click(screen.getByRole("button", { name: /criar usuário/i }));
+
+    expect(axiosMock.post).toHaveBeenCalled();
+    const [createUrl, createPayload, createConfig] = axiosMock.post.mock.calls[0];
+    expect(createUrl).toMatch(/\/user-maintenance$/);
+    expect(createPayload).toMatchObject({
+      name: "Maria Souza",
+      email: "maria.souza@example.com",
+      responsibilities: ["partners.approval.fiscal"],
+      status: "active"
+    });
+    expect(createConfig?.headers?.Authorization).toBe("Bearer token");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: /novo usuário/i })).not.toBeInTheDocument();
+    });
+  });
+
+  it("edits, updates status and deletes an user", async () => {
+    const user = userEvent.setup();
+    const baseUser = {
+      id: "u-001",
+      name: "Ana Lima",
+      email: "ana.lima@example.com",
+      profile: "fiscal",
+      responsibilities: ["partners.approval.fiscal"],
+      status: "active" as const,
+      lastAccessAt: null
+    };
+
+    axiosMock.get.mockResolvedValue({ data: [baseUser] });
+
+    const updatedUser = {
+      ...baseUser,
+      name: "Ana Atualizada",
+      responsibilities: ["partners.review"],
+      profile: "compras"
+    };
+
+    axiosMock.put.mockResolvedValue({ data: updatedUser });
+
+    const statusUpdatedUser = {
+      ...updatedUser,
+      status: "blocked" as const
+    };
+
+    axiosMock.patch.mockResolvedValue({ data: statusUpdatedUser });
+    axiosMock.delete.mockResolvedValue({ data: {} });
+
+    render(<UserMaintenancePage />);
+
+    const row = await screen.findByRole("row", { name: /ana lima/i });
+
+    await user.click(within(row).getByRole("button", { name: /editar/i }));
+
+    const nameInput = screen.getByLabelText(/nome/i);
+    await user.clear(nameInput);
+    await user.type(nameInput, "Ana Atualizada");
+
+    const profileInput = screen.getByLabelText(/perfil/i);
+    await user.clear(profileInput);
+    await user.type(profileInput, "compras");
+
+    const responsibilitiesInput = screen.getByLabelText(/responsabilidades/i);
+    await user.clear(responsibilitiesInput);
+    await user.type(responsibilitiesInput, "partners.review");
+
+    await user.click(screen.getByRole("button", { name: /salvar alterações/i }));
+
+    expect(axiosMock.put).toHaveBeenCalled();
+    const [updateUrl, updatePayload, updateConfig] = axiosMock.put.mock.calls[0];
+    expect(updateUrl).toMatch(new RegExp(`/user-maintenance/${baseUser.id}$`));
+    expect(updatePayload).toMatchObject({
+      name: "Ana Atualizada",
+      profile: "compras",
+      responsibilities: ["partners.review"]
+    });
+    expect(updateConfig?.headers?.Authorization).toBe("Bearer token");
+
+    // Debugging output to inspect DOM and calls when the test fails
+    // console.log("PUT calls", axiosMock.put.mock.calls);
+    // console.log("Rendered HTML", document.body.innerHTML);
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: /editar usuário/i })).not.toBeInTheDocument();
+    });
+
+    await user.click(within(row).getByRole("button", { name: /alterar status/i }));
+    await user.selectOptions(screen.getByLabelText(/status do usuário/i), "blocked");
+    await user.click(screen.getByRole("button", { name: /atualizar status/i }));
+
+    expect(axiosMock.patch).toHaveBeenCalled();
+    const [statusUrl, statusPayload, statusConfig] = axiosMock.patch.mock.calls[0];
+    expect(statusUrl).toMatch(new RegExp(`/user-maintenance/${baseUser.id}$`));
+    expect(statusPayload).toMatchObject({ status: "blocked" });
+    expect(statusConfig?.headers?.Authorization).toBe("Bearer token");
+
+    await waitFor(() => {
+      expect(screen.queryByRole("dialog", { name: /alterar status/i })).not.toBeInTheDocument();
+    });
+
+    await screen.findByText("Bloqueado");
+
+    await user.click(within(row).getByRole("button", { name: /excluir/i }));
+    const confirmDialog = await screen.findByRole("alertdialog", { name: /excluir usuário/i });
+    await user.click(within(confirmDialog).getByRole("button", { name: /^excluir$/i }));
+
+    expect(axiosMock.delete).toHaveBeenCalled();
+    const [deleteUrl, deleteConfig] = axiosMock.delete.mock.calls[0];
+    expect(deleteUrl).toMatch(new RegExp(`/user-maintenance/${baseUser.id}$`));
+    expect(deleteConfig?.headers?.Authorization).toBe("Bearer token");
+
+    await waitFor(() => {
+      expect(screen.queryByText(/ana atualizada/i)).not.toBeInTheDocument();
+      expect(screen.queryByRole("alertdialog", { name: /excluir usuário/i })).not.toBeInTheDocument();
+    });
+  });
+});

--- a/mdm-platform/apps/web/src/app/(protected)/user-maintenance/page.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/user-maintenance/page.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { useEffect, useMemo, useState } from "react";
+import React, { ChangeEvent, FormEvent, useEffect, useMemo, useState } from "react";
 import axios from "axios";
 import { useRouter } from "next/navigation";
-import { UserCog } from "lucide-react";
+import { Pencil, Plus, RefreshCcw, Trash2, UserCog, X } from "lucide-react";
 
 import { getStoredUser } from "../../../lib/auth";
 
@@ -19,17 +19,64 @@ type ManagedUser = {
 
 type ManagedUserResponse = ManagedUser[];
 
+type FormState = {
+  name: string;
+  email: string;
+  profile: string;
+  responsibilities: string;
+  status: ManagedUser["status"];
+};
+
 const statusLabels: Record<ManagedUser["status"], string> = {
   active: "Ativo",
   invited: "Convite pendente",
   blocked: "Bloqueado"
 };
 
+const statusOptions = Object.entries(statusLabels) as Array<
+  [ManagedUser["status"], string]
+>;
+
+const createEmptyFormState = (): FormState => ({
+  name: "",
+  email: "",
+  profile: "",
+  responsibilities: "",
+  status: "invited"
+});
+
+const sanitizeResponsibilities = (value: string): string[] =>
+  value
+    .split(",")
+    .map((item) => item.trim())
+    .filter((item) => item.length > 0);
+
+const formatResponsibilities = (responsibilities: string[]): string =>
+  responsibilities.join(", ");
+
 export default function UserMaintenancePage() {
   const router = useRouter();
+  const apiBaseUrl = process.env.NEXT_PUBLIC_API_URL ?? "";
   const [users, setUsers] = useState<ManagedUser[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+
+  const [formState, setFormState] = useState<FormState>(createEmptyFormState());
+  const [formMode, setFormMode] = useState<"create" | "edit">("create");
+  const [activeUserId, setActiveUserId] = useState<string | null>(null);
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const [isStatusOpen, setIsStatusOpen] = useState(false);
+  const [statusUserId, setStatusUserId] = useState<string | null>(null);
+  const [statusValue, setStatusValue] = useState<ManagedUser["status"]>("active");
+  const [statusError, setStatusError] = useState<string | null>(null);
+  const [isStatusSubmitting, setIsStatusSubmitting] = useState(false);
+
+  const [confirmUser, setConfirmUser] = useState<ManagedUser | null>(null);
+  const [deleteError, setDeleteError] = useState<string | null>(null);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const currentUser = useMemo(() => getStoredUser(), []);
 
@@ -43,7 +90,7 @@ export default function UserMaintenancePage() {
 
       try {
         const response = await axios.get<ManagedUserResponse>(
-          `${process.env.NEXT_PUBLIC_API_URL}/user-maintenance`,
+          `${apiBaseUrl}/user-maintenance`,
           {
             headers: { Authorization: `Bearer ${token}` }
           }
@@ -58,7 +105,11 @@ export default function UserMaintenancePage() {
           return;
         }
         const message = err?.response?.data?.message;
-        setError(typeof message === "string" ? message : "Não foi possível carregar a lista de usuários.");
+        setError(
+          typeof message === "string"
+            ? message
+            : "Não foi possível carregar a lista de usuários."
+        );
       } finally {
         setLoading(false);
       }
@@ -68,19 +119,233 @@ export default function UserMaintenancePage() {
   }, [router]);
 
   const metrics = useMemo(() => {
-    const totals = { active: 0, invited: 0, blocked: 0 } as Record<ManagedUser["status"], number>;
+    const totals = { active: 0, invited: 0, blocked: 0 } as Record<
+      ManagedUser["status"],
+      number
+    >;
     users.forEach((user) => {
       totals[user.status] += 1;
     });
     return totals;
   }, [users]);
 
+  const openCreateForm = () => {
+    setFormMode("create");
+    setFormState(createEmptyFormState());
+    setFormError(null);
+    setActiveUserId(null);
+    setIsFormOpen(true);
+  };
+
+  const openEditForm = (user: ManagedUser) => {
+    setFormMode("edit");
+    setActiveUserId(user.id);
+    setFormState({
+      name: user.name,
+      email: user.email,
+      profile: user.profile ?? "",
+      responsibilities: formatResponsibilities(user.responsibilities),
+      status: user.status
+    });
+    setFormError(null);
+    setIsFormOpen(true);
+  };
+
+  const closeForm = () => {
+    setIsFormOpen(false);
+    setFormError(null);
+    setIsSubmitting(false);
+    setActiveUserId(null);
+  };
+
+  const handleFormChange = (field: keyof FormState) => (
+    event: ChangeEvent<
+      HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement
+    >
+  ) => {
+    setFormState((prev) => ({ ...prev, [field]: event.target.value }));
+  };
+
+  const handleFormSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFormError(null);
+
+    const name = formState.name.trim();
+    const email = formState.email.trim();
+    const responsibilities = sanitizeResponsibilities(formState.responsibilities);
+
+    if (!name) {
+      setFormError("Informe o nome do usuário.");
+      return;
+    }
+
+    if (!email || !email.includes("@")) {
+      setFormError("Informe um e-mail válido.");
+      return;
+    }
+
+    if (responsibilities.length === 0) {
+      setFormError("Informe ao menos uma responsabilidade.");
+      return;
+    }
+
+    const token = localStorage.getItem("mdmToken");
+    if (!token) {
+      router.replace("/login");
+      return;
+    }
+
+    const payload = {
+      name,
+      email,
+      profile: formState.profile.trim() ? formState.profile.trim() : null,
+      responsibilities,
+      status: formState.status
+    };
+
+    try {
+      setIsSubmitting(true);
+      if (formMode === "create") {
+        const response = await axios.post<ManagedUser>(
+          `${apiBaseUrl}/user-maintenance`,
+          payload,
+          {
+            headers: { Authorization: `Bearer ${token}` }
+          }
+        );
+        setUsers((prev) => [...prev, response.data]);
+      } else if (activeUserId) {
+        const response = await axios.put<ManagedUser>(
+          `${apiBaseUrl}/user-maintenance/${activeUserId}`,
+          payload,
+          {
+            headers: { Authorization: `Bearer ${token}` }
+          }
+        );
+        setUsers((prev) =>
+          prev.map((user) => (user.id === activeUserId ? response.data : user))
+        );
+      }
+      closeForm();
+    } catch (err: any) {
+      const message = err?.response?.data?.message;
+      setFormError(
+        typeof message === "string"
+          ? message
+          : "Não foi possível salvar o usuário."
+      );
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const openStatusModal = (user: ManagedUser) => {
+    setStatusUserId(user.id);
+    setStatusValue(user.status);
+    setStatusError(null);
+    setIsStatusOpen(true);
+  };
+
+  const closeStatusModal = () => {
+    setIsStatusOpen(false);
+    setStatusUserId(null);
+    setStatusError(null);
+    setIsStatusSubmitting(false);
+  };
+
+  const handleStatusSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!statusUserId) {
+      return;
+    }
+
+    const token = localStorage.getItem("mdmToken");
+    if (!token) {
+      router.replace("/login");
+      return;
+    }
+
+    try {
+      setIsStatusSubmitting(true);
+      const response = await axios.patch<ManagedUser>(
+        `${apiBaseUrl}/user-maintenance/${statusUserId}`,
+        { status: statusValue },
+        {
+          headers: { Authorization: `Bearer ${token}` }
+        }
+      );
+      setUsers((prev) =>
+        prev.map((user) => (user.id === statusUserId ? response.data : user))
+      );
+      closeStatusModal();
+    } catch (err: any) {
+      const message = err?.response?.data?.message;
+      setStatusError(
+        typeof message === "string"
+          ? message
+          : "Não foi possível atualizar o status do usuário."
+      );
+    } finally {
+      setIsStatusSubmitting(false);
+    }
+  };
+
+  const openDeleteConfirmation = (user: ManagedUser) => {
+    setConfirmUser(user);
+    setDeleteError(null);
+  };
+
+  const closeDeleteConfirmation = () => {
+    setConfirmUser(null);
+    setDeleteError(null);
+    setIsDeleting(false);
+  };
+
+  const handleDelete = async () => {
+    if (!confirmUser) {
+      return;
+    }
+
+    const token = localStorage.getItem("mdmToken");
+    if (!token) {
+      router.replace("/login");
+      return;
+    }
+
+    try {
+      setIsDeleting(true);
+      await axios.delete(`${apiBaseUrl}/user-maintenance/${confirmUser.id}`, {
+        headers: { Authorization: `Bearer ${token}` }
+      });
+      setUsers((prev) => prev.filter((user) => user.id !== confirmUser.id));
+      closeDeleteConfirmation();
+    } catch (err: any) {
+      const message = err?.response?.data?.message;
+      setDeleteError(
+        typeof message === "string"
+          ? message
+          : "Não foi possível excluir o usuário."
+      );
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
   return (
     <main className="flex min-h-screen flex-col gap-6 bg-zinc-100 p-6">
-      <header className="flex flex-col gap-2">
-        <div className="flex items-center gap-2 text-zinc-900">
-          <UserCog className="h-6 w-6" />
-          <h1 className="text-2xl font-semibold">Manutenção de Usuários</h1>
+      <header className="flex flex-col gap-4">
+        <div className="flex flex-col gap-2 text-zinc-900 md:flex-row md:items-center md:justify-between">
+          <div className="flex items-center gap-2">
+            <UserCog className="h-6 w-6" />
+            <h1 className="text-2xl font-semibold">Manutenção de Usuários</h1>
+          </div>
+          <button
+            type="button"
+            onClick={openCreateForm}
+            className="inline-flex items-center justify-center gap-2 rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700"
+          >
+            <Plus className="h-4 w-4" /> Novo usuário
+          </button>
         </div>
         <p className="text-sm text-zinc-500">
           Visualize perfis, responsabilidades e status de acesso dos colaboradores que atuam no processo de MDM.
@@ -121,6 +386,7 @@ export default function UserMaintenancePage() {
                   <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-zinc-500">Responsabilidades</th>
                   <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-zinc-500">Status</th>
                   <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-zinc-500">Último acesso</th>
+                  <th className="px-4 py-3 text-xs font-semibold uppercase tracking-wide text-zinc-500">Ações</th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-zinc-200 text-sm text-zinc-600">
@@ -170,6 +436,31 @@ export default function UserMaintenancePage() {
                         </span>
                       </td>
                       <td className="px-4 py-3 text-xs text-zinc-500">{lastAccess}</td>
+                      <td className="px-4 py-3">
+                        <div className="flex flex-wrap gap-2">
+                          <button
+                            type="button"
+                            onClick={() => openEditForm(user)}
+                            className="inline-flex items-center gap-1 rounded-lg border border-zinc-200 px-2 py-1 text-xs font-semibold text-zinc-600 transition hover:border-zinc-300 hover:text-zinc-900"
+                          >
+                            <Pencil className="h-3.5 w-3.5" /> Editar
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => openStatusModal(user)}
+                            className="inline-flex items-center gap-1 rounded-lg border border-zinc-200 px-2 py-1 text-xs font-semibold text-zinc-600 transition hover:border-zinc-300 hover:text-zinc-900"
+                          >
+                            <RefreshCcw className="h-3.5 w-3.5" /> Alterar status
+                          </button>
+                          <button
+                            type="button"
+                            onClick={() => openDeleteConfirmation(user)}
+                            className="inline-flex items-center gap-1 rounded-lg border border-red-200 px-2 py-1 text-xs font-semibold text-red-600 transition hover:border-red-300 hover:text-red-700"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" /> Excluir
+                          </button>
+                        </div>
+                      </td>
                     </tr>
                   );
                 })}
@@ -181,6 +472,234 @@ export default function UserMaintenancePage() {
           </section>
         </>
       )}
+
+      {isFormOpen ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="user-form-title"
+            className="w-full max-w-lg rounded-2xl bg-white p-6 shadow-xl"
+          >
+            <div className="mb-4 flex items-start justify-between">
+              <h2 id="user-form-title" className="text-lg font-semibold text-zinc-900">
+                {formMode === "create" ? "Novo usuário" : "Editar usuário"}
+              </h2>
+              <button
+                type="button"
+                onClick={closeForm}
+                className="rounded-full p-1 text-zinc-500 transition hover:bg-zinc-100 hover:text-zinc-700"
+                aria-label="Fechar"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <form onSubmit={handleFormSubmit} className="flex flex-col gap-4">
+              <label className="flex flex-col gap-2 text-sm text-zinc-600" htmlFor="name">
+                Nome
+                <input
+                  id="name"
+                  name="name"
+                  value={formState.name}
+                  onChange={handleFormChange("name")}
+                  className="rounded-lg border border-zinc-300 px-3 py-2 text-sm text-zinc-900 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                  placeholder="Digite o nome completo"
+                />
+              </label>
+
+              <label className="flex flex-col gap-2 text-sm text-zinc-600" htmlFor="email">
+                E-mail
+                <input
+                  id="email"
+                  name="email"
+                  type="email"
+                  value={formState.email}
+                  onChange={handleFormChange("email")}
+                  className="rounded-lg border border-zinc-300 px-3 py-2 text-sm text-zinc-900 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                  placeholder="usuario@empresa.com"
+                />
+              </label>
+
+              <label className="flex flex-col gap-2 text-sm text-zinc-600" htmlFor="profile">
+                Perfil
+                <input
+                  id="profile"
+                  name="profile"
+                  value={formState.profile}
+                  onChange={handleFormChange("profile")}
+                  className="rounded-lg border border-zinc-300 px-3 py-2 text-sm text-zinc-900 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                  placeholder="Perfil do usuário"
+                />
+              </label>
+
+              <label className="flex flex-col gap-2 text-sm text-zinc-600" htmlFor="responsibilities">
+                Responsabilidades (separe por vírgulas)
+                <textarea
+                  id="responsibilities"
+                  name="responsibilities"
+                  value={formState.responsibilities}
+                  onChange={handleFormChange("responsibilities")}
+                  className="min-h-[96px] rounded-lg border border-zinc-300 px-3 py-2 text-sm text-zinc-900 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                  placeholder="partners.approval.fiscal, partners.approval.compras"
+                />
+              </label>
+
+              <label className="flex flex-col gap-2 text-sm text-zinc-600" htmlFor="status">
+                Status
+                <select
+                  id="status"
+                  name="status"
+                  value={formState.status}
+                  onChange={handleFormChange("status")}
+                  className="rounded-lg border border-zinc-300 px-3 py-2 text-sm text-zinc-900 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                >
+                  {statusOptions.map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              {formError ? <p className="text-sm text-red-600">{formError}</p> : null}
+
+              <div className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+                <button
+                  type="button"
+                  onClick={closeForm}
+                  className="rounded-lg border border-zinc-300 px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:border-zinc-400 hover:text-zinc-900"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  disabled={isSubmitting}
+                  className="inline-flex items-center justify-center rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isSubmitting
+                    ? "Salvando..."
+                    : formMode === "create"
+                      ? "Criar usuário"
+                      : "Salvar alterações"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+
+      {isStatusOpen && statusUserId ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="status-modal-title"
+            className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl"
+          >
+            <div className="mb-4 flex items-start justify-between">
+              <h2 id="status-modal-title" className="text-lg font-semibold text-zinc-900">
+                Alterar status
+              </h2>
+              <button
+                type="button"
+                onClick={closeStatusModal}
+                className="rounded-full p-1 text-zinc-500 transition hover:bg-zinc-100 hover:text-zinc-700"
+                aria-label="Fechar"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <form onSubmit={handleStatusSubmit} className="flex flex-col gap-4">
+              <label className="flex flex-col gap-2 text-sm text-zinc-600" htmlFor="status-select">
+                Status do usuário
+                <select
+                  id="status-select"
+                  name="status"
+                  value={statusValue}
+                  onChange={(event) =>
+                    setStatusValue(event.target.value as ManagedUser["status"])
+                  }
+                  className="rounded-lg border border-zinc-300 px-3 py-2 text-sm text-zinc-900 focus:border-emerald-500 focus:outline-none focus:ring-2 focus:ring-emerald-200"
+                >
+                  {statusOptions.map(([value, label]) => (
+                    <option key={value} value={value}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              </label>
+
+              {statusError ? <p className="text-sm text-red-600">{statusError}</p> : null}
+
+              <div className="flex justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={closeStatusModal}
+                  className="rounded-lg border border-zinc-300 px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:border-zinc-400 hover:text-zinc-900"
+                >
+                  Cancelar
+                </button>
+                <button
+                  type="submit"
+                  disabled={isStatusSubmitting}
+                  className="inline-flex items-center justify-center rounded-lg bg-emerald-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-emerald-700 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isStatusSubmitting ? "Atualizando..." : "Atualizar status"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      ) : null}
+
+      {confirmUser ? (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/40 px-4">
+          <div
+            role="alertdialog"
+            aria-modal="true"
+            aria-labelledby="delete-modal-title"
+            aria-describedby="delete-modal-description"
+            className="w-full max-w-md rounded-2xl bg-white p-6 shadow-xl"
+          >
+            <div className="mb-4 flex items-start justify-between">
+              <h2 id="delete-modal-title" className="text-lg font-semibold text-zinc-900">
+                Excluir usuário
+              </h2>
+              <button
+                type="button"
+                onClick={closeDeleteConfirmation}
+                className="rounded-full p-1 text-zinc-500 transition hover:bg-zinc-100 hover:text-zinc-700"
+                aria-label="Fechar"
+              >
+                <X className="h-4 w-4" />
+              </button>
+            </div>
+            <p id="delete-modal-description" className="text-sm text-zinc-600">
+              Tem certeza de que deseja remover {confirmUser.name}? Essa ação não poderá ser desfeita.
+            </p>
+
+            {deleteError ? <p className="mt-4 text-sm text-red-600">{deleteError}</p> : null}
+
+            <div className="mt-6 flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={closeDeleteConfirmation}
+                className="rounded-lg border border-zinc-300 px-4 py-2 text-sm font-semibold text-zinc-700 transition hover:border-zinc-400 hover:text-zinc-900"
+              >
+                Cancelar
+              </button>
+              <button
+                type="button"
+                onClick={handleDelete}
+                disabled={isDeleting}
+                className="inline-flex items-center justify-center rounded-lg bg-red-600 px-4 py-2 text-sm font-semibold text-white shadow-sm transition hover:bg-red-700 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {isDeleting ? "Excluindo..." : "Excluir"}
+              </button>
+            </div>
+          </div>
+        </div>
+      ) : null}
     </main>
   );
 }

--- a/mdm-platform/package.json
+++ b/mdm-platform/package.json
@@ -11,6 +11,10 @@
     "dev:up": "docker compose -f infra/docker/docker-compose.dev.yml up -d"
   },
   "devDependencies": {
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
+    "jsdom": "^24.1.0",
     "turbo": "^2.0.0",
     "vitest": "^2.1.4"
   }

--- a/mdm-platform/pnpm-lock.yaml
+++ b/mdm-platform/pnpm-lock.yaml
@@ -8,12 +8,24 @@ importers:
 
   .:
     devDependencies:
+      '@testing-library/jest-dom':
+        specifier: ^6.6.3
+        version: 6.9.1
+      '@testing-library/react':
+        specifier: ^16.1.0
+        version: 16.3.0(@testing-library/dom@10.4.1)(@types/react@19.1.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)
+      '@testing-library/user-event':
+        specifier: ^14.5.2
+        version: 14.6.1(@testing-library/dom@10.4.1)
+      jsdom:
+        specifier: ^24.1.0
+        version: 24.1.3
       turbo:
         specifier: ^2.0.0
         version: 2.5.8
       vitest:
         specifier: ^2.1.4
-        version: 2.1.9(@types/node@20.19.17)(terser@5.44.0)
+        version: 2.1.9(@types/node@20.19.17)(jsdom@24.1.3)(terser@5.44.0)
 
   apps/api:
     dependencies:
@@ -107,7 +119,7 @@ importers:
         version: 5.9.2
       vitest:
         specifier: ^2.1.4
-        version: 2.1.9(@types/node@20.19.17)(terser@5.44.0)
+        version: 2.1.9(@types/node@20.19.17)(jsdom@24.1.3)(terser@5.44.0)
 
   apps/web:
     dependencies:
@@ -187,6 +199,9 @@ importers:
 
 packages:
 
+  '@adobe/css-tools@4.4.4':
+    resolution: {integrity: sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==}
+
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
@@ -209,12 +224,19 @@ packages:
     resolution: {integrity: sha512-I5wviiIqiFwar9Pdk30Lujk8FczEEc18i22A5c6Z9lbmhPQdTroDnEQdsfXjy404wPe8H62s0I15o4pmMGfTYQ==}
     engines: {node: ^18.13.0 || >=20.9.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
 
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
   '@babel/code-frame@7.27.1':
     resolution: {integrity: sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==}
     engines: {node: '>=6.9.0'}
 
   '@babel/helper-validator-identifier@7.27.1':
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.28.4':
+    resolution: {integrity: sha512-Q/N6JNWvIvPnLDvjlE1OUBLPQHH6l3CltCEsHIujp45zQUSSh8K+gHnaEX45yAT1nyngnINhvWtzN+Nb9D8RAQ==}
     engines: {node: '>=6.9.0'}
 
   '@borewit/text-codec@0.1.1':
@@ -227,6 +249,34 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -728,6 +778,35 @@ packages:
   '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/jest-dom@6.9.1':
+    resolution: {integrity: sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==}
+    engines: {node: '>=14', npm: '>=6', yarn: '>=1'}
+
+  '@testing-library/react@16.3.0':
+    resolution: {integrity: sha512-kFSyxiEDwv1WLl2fgsq6pPBbw5aWKrsY2/noi1Id0TK0UParSF62oFQFGHXIyaG4pp2tEub/Zlel+fjjZILDsw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
+
   '@tokenizer/inflate@0.2.7':
     resolution: {integrity: sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==}
     engines: {node: '>=18'}
@@ -746,6 +825,9 @@ packages:
 
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
 
   '@types/body-parser@1.19.6':
     resolution: {integrity: sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g==}
@@ -903,6 +985,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-formats@2.1.1:
     resolution: {integrity: sha512-Wx0Kx52hxE7C18hkMEggYlEifqWZtYaRgouJor+WMdPnQyEK13vgEWyVNup7SoeeoLMsr4kf5h6dOW11I15MUA==}
     peerDependencies:
@@ -950,6 +1036,10 @@ packages:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
 
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
+
   ansi-styles@6.2.3:
     resolution: {integrity: sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==}
     engines: {node: '>=12'}
@@ -980,6 +1070,13 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
+
+  aria-query@5.3.2:
+    resolution: {integrity: sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==}
+    engines: {node: '>= 0.4'}
 
   array-flatten@1.1.1:
     resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
@@ -1231,13 +1328,24 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  css.escape@1.5.1:
+    resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
+
   cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   dayjs@1.11.18:
     resolution: {integrity: sha512-zFBQ7WFRvVRhKcWoUh+ZA1g2HVgUbsZm9sbddh8EC5iv93sui8DVVz1Npvz+r6meo9VKfa8NyLWBsQK1VvIKPA==}
@@ -1258,6 +1366,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
 
   dedent@1.7.0:
     resolution: {integrity: sha512-HGFtf8yhuhGhqO07SV79tRp+br4MnbdjeVxotpn1QBl30pcLLCQjX5b2295ll0fv8RKDKsmWYrl05usHM9CewQ==}
@@ -1290,6 +1401,10 @@ packages:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
   destroy@1.2.0:
     resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
     engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
@@ -1303,6 +1418,12 @@ packages:
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-accessibility-api@0.6.3:
+    resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
 
   dotenv-expand@12.0.1:
     resolution: {integrity: sha512-LaKRbou8gt0RNID/9RoI+J2rvXsBRPMV7p+ElHlPhcSARbCPDYcYG2s1TIzAfWv4YSgyY5taidWzzs31lNV3yQ==}
@@ -1352,6 +1473,10 @@ packages:
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
     engines: {node: '>=10.13.0'}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   error-ex@1.3.4:
     resolution: {integrity: sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ==}
@@ -1591,12 +1716,28 @@ packages:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
   http-errors@2.0.0:
     resolution: {integrity: sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==}
     engines: {node: '>= 0.8'}
 
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
   iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -1605,6 +1746,10 @@ packages:
   import-fresh@3.3.1:
     resolution: {integrity: sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==}
     engines: {node: '>=6'}
+
+  indent-string@4.0.0:
+    resolution: {integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==}
+    engines: {node: '>=8'}
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
@@ -1660,6 +1805,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-typed-array@1.1.15:
     resolution: {integrity: sha512-p3EcsicXjit7SaskXHs1hA91QxgTw46Fv6EFKKGS5DRFLD8yKnohjF3hxoju94b/OcMZoQukzpPpBE9uLVKzgQ==}
     engines: {node: '>= 0.4'}
@@ -1695,6 +1843,15 @@ packages:
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
     hasBin: true
+
+  jsdom@24.1.3:
+    resolution: {integrity: sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
 
   json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
@@ -1794,6 +1951,10 @@ packages:
     resolution: {integrity: sha512-An0UCfG/rSiqtAIiBPO0Y9/zAnHUZxAMiCpTd5h2smgsj7GGmcenvrvww2cqNA8/4A5ZrD1gJpHN2mIHZQF+Mg==}
     engines: {node: '>=12'}
 
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
+
   magic-string@0.30.19:
     resolution: {integrity: sha512-2N21sPY9Ws53PZvsEpVtNuSW+ScYbQdp4b9qUaL+9QkHUrGFKo56Lg9Emg5s9V/qrtNBmiR01sYhUOwu3H+VOw==}
 
@@ -1850,6 +2011,10 @@ packages:
   mimic-fn@2.1.0:
     resolution: {integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==}
     engines: {node: '>=6'}
+
+  min-indent@1.0.1:
+    resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
+    engines: {node: '>=4'}
 
   minimatch@3.1.2:
     resolution: {integrity: sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==}
@@ -1950,6 +2115,9 @@ packages:
     resolution: {integrity: sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==}
     engines: {node: '>=0.10.0'}
 
+  nwsapi@2.2.22:
+    resolution: {integrity: sha512-ujSMe1OWVn55euT1ihwCI1ZcAaAU3nxUiDwfDQldc51ZXaB9m2AyOn6/jh1BLe2t/G8xd6uKG1UBF2aZJeg2SQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -1991,6 +2159,9 @@ packages:
   parse-json@5.2.0:
     resolution: {integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==}
     engines: {node: '>=8'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   parseurl@1.3.3:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
@@ -2164,12 +2335,19 @@ packages:
     resolution: {integrity: sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==}
     engines: {node: '>=0.10.0'}
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   proxy-addr@2.0.7:
     resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
     engines: {node: '>= 0.10'}
 
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
+
+  psl@1.15.0:
+    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
 
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
@@ -2178,6 +2356,9 @@ packages:
   qs@6.13.0:
     resolution: {integrity: sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==}
     engines: {node: '>=0.6'}
+
+  querystringify@2.2.0:
+    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -2204,6 +2385,9 @@ packages:
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18 || ^19
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
   react@18.2.0:
     resolution: {integrity: sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==}
     engines: {node: '>=0.10.0'}
@@ -2219,6 +2403,10 @@ packages:
     resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
     engines: {node: '>=8.10.0'}
 
+  redent@3.0.0:
+    resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
+    engines: {node: '>=8'}
+
   reflect-metadata@0.1.14:
     resolution: {integrity: sha512-ZhYeb6nRaXCfhnndflDK8qI6ZQ/YcWZCISRAWICW9XYqMUwjZM9Z0DveWX/ABN01oxSHwVxKQmxeYZSsm0jh5A==}
 
@@ -2233,6 +2421,9 @@ packages:
   require-from-string@2.0.2:
     resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
     engines: {node: '>=0.10.0'}
+
+  requires-port@1.0.0:
+    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
 
   resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -2261,6 +2452,12 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-async@2.4.1:
     resolution: {integrity: sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==}
     engines: {node: '>=0.12.0'}
@@ -2283,6 +2480,10 @@ packages:
 
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -2417,6 +2618,10 @@ packages:
     resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
     engines: {node: '>=4'}
 
+  strip-indent@3.0.0:
+    resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
+    engines: {node: '>=8'}
+
   strip-json-comments@2.0.1:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
@@ -2470,6 +2675,9 @@ packages:
   symbol-observable@4.0.0:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
+
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
   tailwindcss@3.4.17:
     resolution: {integrity: sha512-w33E2aCvSDP0tW9RZuNXadXlkHXqFzSkQew/aIa2i/Sj8fThxwovwlXHSPXTbAHwEIhBFXAedUhP2tueAKP8Og==}
@@ -2549,8 +2757,16 @@ packages:
     resolution: {integrity: sha512-kh9LVIWH5CnL63Ipf0jhlBIy0UsrMj/NJDfpsy1SqOXlLKEVyXXYrnFxFT1yOOYVGBSApeVnjPw/sBz5BfEjAQ==}
     engines: {node: '>=14.16'}
 
+  tough-cookie@4.1.4:
+    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
+    engines: {node: '>=6'}
+
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -2729,6 +2945,10 @@ packages:
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
+  universalify@0.2.0:
+    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
+    engines: {node: '>= 4.0.0'}
+
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -2745,6 +2965,9 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
+
+  url-parse@1.5.10:
+    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -2833,6 +3056,10 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
   watchpack@2.4.4:
     resolution: {integrity: sha512-c5EGNOiyxxV5qmTtAB7rbiXxi1ooX1pQKMLX/MIabJjRA0SJBQOjKF+KSVfHkr9U1cADPon0mRiVe/riyaiDUA==}
     engines: {node: '>=10.13.0'}
@@ -2842,6 +3069,10 @@ packages:
 
   webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
 
   webpack-node-externals@3.0.0:
     resolution: {integrity: sha512-LnL6Z3GGDPht/AigwRh2dvL9PQPFQ8skEpVrWZXLWBYmqcaojHNN0onvHzie6rq7EWKrrBfPYqNEzTJgiwEQDQ==}
@@ -2860,6 +3091,18 @@ packages:
     peerDependenciesMeta:
       webpack-cli:
         optional: true
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -2893,6 +3136,25 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
     engines: {node: '>=0.4'}
@@ -2922,6 +3184,8 @@ packages:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
 snapshots:
+
+  '@adobe/css-tools@4.4.4': {}
 
   '@alloc/quick-lru@5.2.0': {}
 
@@ -2957,6 +3221,14 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
   '@babel/code-frame@7.27.1':
     dependencies:
       '@babel/helper-validator-identifier': 7.27.1
@@ -2964,6 +3236,8 @@ snapshots:
       picocolors: 1.1.1
 
   '@babel/helper-validator-identifier@7.27.1': {}
+
+  '@babel/runtime@7.28.4': {}
 
   '@borewit/text-codec@0.1.1': {}
 
@@ -2973,6 +3247,26 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -3360,6 +3654,39 @@ snapshots:
       '@swc/counter': 0.1.3
       tslib: 2.8.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/runtime': 7.28.4
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/jest-dom@6.9.1':
+    dependencies:
+      '@adobe/css-tools': 4.4.4
+      aria-query: 5.3.2
+      css.escape: 1.5.1
+      dom-accessibility-api: 0.6.3
+      picocolors: 1.1.1
+      redent: 3.0.0
+
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.1)(@types/react@19.1.15)(react-dom@18.2.0(react@18.2.0))(react@18.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@testing-library/dom': 10.4.1
+      react: 18.2.0
+      react-dom: 18.2.0(react@18.2.0)
+    optionalDependencies:
+      '@types/react': 19.1.15
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
+
   '@tokenizer/inflate@0.2.7':
     dependencies:
       debug: 4.4.3
@@ -3377,6 +3704,8 @@ snapshots:
   '@tsconfig/node14@1.0.3': {}
 
   '@tsconfig/node16@1.0.4': {}
+
+  '@types/aria-query@5.0.4': {}
 
   '@types/body-parser@1.19.6':
     dependencies:
@@ -3585,6 +3914,8 @@ snapshots:
 
   acorn@8.15.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv-formats@2.1.1(ajv@8.12.0):
     optionalDependencies:
       ajv: 8.12.0
@@ -3637,6 +3968,8 @@ snapshots:
     dependencies:
       color-convert: 2.0.1
 
+  ansi-styles@5.2.0: {}
+
   ansi-styles@6.2.3: {}
 
   ansis@3.17.0: {}
@@ -3657,6 +3990,12 @@ snapshots:
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
+
+  aria-query@5.3.2: {}
 
   array-flatten@1.1.1: {}
 
@@ -3926,9 +4265,21 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  css.escape@1.5.1: {}
+
   cssesc@3.0.0: {}
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.1.3: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   dayjs@1.11.18: {}
 
@@ -3939,6 +4290,8 @@ snapshots:
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js@10.6.0: {}
 
   dedent@1.7.0: {}
 
@@ -3960,6 +4313,8 @@ snapshots:
 
   depd@2.0.0: {}
 
+  dequal@2.0.3: {}
+
   destroy@1.2.0: {}
 
   didyoumean@1.2.2: {}
@@ -3967,6 +4322,10 @@ snapshots:
   diff@4.0.2: {}
 
   dlv@1.1.3: {}
+
+  dom-accessibility-api@0.5.16: {}
+
+  dom-accessibility-api@0.6.3: {}
 
   dotenv-expand@12.0.1:
     dependencies:
@@ -4008,6 +4367,8 @@ snapshots:
     dependencies:
       graceful-fs: 4.2.11
       tapable: 2.2.3
+
+  entities@6.0.1: {}
 
   error-ex@1.3.4:
     dependencies:
@@ -4307,6 +4668,10 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
   http-errors@2.0.0:
     dependencies:
       depd: 2.0.0
@@ -4315,7 +4680,25 @@ snapshots:
       statuses: 2.0.1
       toidentifier: 1.0.1
 
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
   iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  iconv-lite@0.6.3:
     dependencies:
       safer-buffer: 2.1.2
 
@@ -4325,6 +4708,8 @@ snapshots:
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
+
+  indent-string@4.0.0: {}
 
   inflight@1.0.6:
     dependencies:
@@ -4395,6 +4780,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-typed-array@1.1.15:
     dependencies:
       which-typed-array: 1.1.19
@@ -4426,6 +4813,34 @@ snapshots:
   js-yaml@4.1.0:
     dependencies:
       argparse: 2.0.1
+
+  jsdom@24.1.3:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.4
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.22
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 4.1.4
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.18.3
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   json-parse-even-better-errors@2.3.1: {}
 
@@ -4514,6 +4929,8 @@ snapshots:
 
   luxon@3.3.0: {}
 
+  lz-string@1.5.0: {}
+
   magic-string@0.30.19:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -4554,6 +4971,8 @@ snapshots:
   mime@1.6.0: {}
 
   mimic-fn@2.1.0: {}
+
+  min-indent@1.0.1: {}
 
   minimatch@3.1.2:
     dependencies:
@@ -4644,6 +5063,8 @@ snapshots:
 
   normalize-range@0.1.2: {}
 
+  nwsapi@2.2.22: {}
+
   object-assign@4.1.1: {}
 
   object-hash@3.0.0: {}
@@ -4688,6 +5109,10 @@ snapshots:
       error-ex: 1.3.4
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.2.4
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   parseurl@1.3.3: {}
 
@@ -4830,6 +5255,12 @@ snapshots:
     dependencies:
       xtend: 4.0.2
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   proxy-addr@2.0.7:
     dependencies:
       forwarded: 0.2.0
@@ -4837,11 +5268,17 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
+  psl@1.15.0:
+    dependencies:
+      punycode: 2.3.1
+
   punycode@2.3.1: {}
 
   qs@6.13.0:
     dependencies:
       side-channel: 1.1.0
+
+  querystringify@2.2.0: {}
 
   queue-microtask@1.2.3: {}
 
@@ -4868,6 +5305,8 @@ snapshots:
     dependencies:
       react: 18.2.0
 
+  react-is@17.0.2: {}
+
   react@18.2.0:
     dependencies:
       loose-envify: 1.4.0
@@ -4886,6 +5325,11 @@ snapshots:
     dependencies:
       picomatch: 2.3.1
 
+  redent@3.0.0:
+    dependencies:
+      indent-string: 4.0.0
+      strip-indent: 3.0.0
+
   reflect-metadata@0.1.14: {}
 
   repeat-string@1.6.1: {}
@@ -4893,6 +5337,8 @@ snapshots:
   require-directory@2.1.1: {}
 
   require-from-string@2.0.2: {}
+
+  requires-port@1.0.0: {}
 
   resolve-from@4.0.0: {}
 
@@ -4941,6 +5387,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.52.3
       fsevents: 2.3.3
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   run-async@2.4.1: {}
 
   run-async@3.0.0: {}
@@ -4960,6 +5410,10 @@ snapshots:
   safe-buffer@5.2.1: {}
 
   safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -5117,6 +5571,10 @@ snapshots:
 
   strip-bom@3.0.0: {}
 
+  strip-indent@3.0.0:
+    dependencies:
+      min-indent: 1.0.1
+
   strip-json-comments@2.0.1: {}
 
   strtok3@10.3.4:
@@ -5160,6 +5618,8 @@ snapshots:
       swagger-ui-dist: 5.29.0
 
   symbol-observable@4.0.0: {}
+
+  symbol-tree@3.2.4: {}
 
   tailwindcss@3.4.17(ts-node@10.9.2(@types/node@20.19.17)(typescript@5.9.2)):
     dependencies:
@@ -5248,7 +5708,18 @@ snapshots:
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
 
+  tough-cookie@4.1.4:
+    dependencies:
+      psl: 1.15.0
+      punycode: 2.3.1
+      universalify: 0.2.0
+      url-parse: 1.5.10
+
   tr46@0.0.3: {}
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   tree-kill@1.2.2: {}
 
@@ -5392,6 +5863,8 @@ snapshots:
 
   undici-types@6.21.0: {}
 
+  universalify@0.2.0: {}
+
   universalify@2.0.1: {}
 
   unpipe@1.0.0: {}
@@ -5405,6 +5878,11 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
+
+  url-parse@1.5.10:
+    dependencies:
+      querystringify: 2.2.0
+      requires-port: 1.0.0
 
   util-deprecate@1.0.2: {}
 
@@ -5448,7 +5926,7 @@ snapshots:
       fsevents: 2.3.3
       terser: 5.44.0
 
-  vitest@2.1.9(@types/node@20.19.17)(terser@5.44.0):
+  vitest@2.1.9(@types/node@20.19.17)(jsdom@24.1.3)(terser@5.44.0):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.20(@types/node@20.19.17)(terser@5.44.0))
@@ -5472,6 +5950,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 20.19.17
+      jsdom: 24.1.3
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -5483,6 +5962,10 @@ snapshots:
       - supports-color
       - terser
 
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
   watchpack@2.4.4:
     dependencies:
       glob-to-regexp: 0.4.1
@@ -5493,6 +5976,8 @@ snapshots:
       defaults: 1.0.4
 
   webidl-conversions@3.0.1: {}
+
+  webidl-conversions@7.0.0: {}
 
   webpack-node-externals@3.0.0: {}
 
@@ -5527,6 +6012,17 @@ snapshots:
       - '@swc/core'
       - esbuild
       - uglify-js
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   whatwg-url@5.0.0:
     dependencies:
@@ -5571,6 +6067,12 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
+
+  ws@8.18.3: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   xtend@4.0.2: {}
 

--- a/mdm-platform/vitest.config.ts
+++ b/mdm-platform/vitest.config.ts
@@ -4,7 +4,9 @@ export default defineConfig({
   test: {
     globals: true,
     environment: "node",
-    include: ["**/*.spec.ts"],
+    include: ["**/*.spec.ts", "**/*.spec.tsx"],
+    environmentMatchGlobs: [["apps/web/**", "jsdom"]],
+    setupFiles: ["./vitest.setup.ts"],
     coverage: {
       reporter: ["text", "html"],
       enabled: false

--- a/mdm-platform/vitest.setup.ts
+++ b/mdm-platform/vitest.setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";


### PR DESCRIPTION
## Summary
- add DTOs, shared types, and service logic to support creating, updating, and removing managed users while validating conflicts
- expose RESTful CRUD endpoints through the user maintenance controller
- enhance the user maintenance page with action buttons, modals, and state updates that call the new API routes, and add unit tests for backend and frontend flows
- configure Vitest with jsdom/testing-library support for web tests

## Testing
- pnpm vitest run apps/api/src/modules/user-maintenance/user-maintenance.service.spec.ts 'apps/web/src/app/(protected)/user-maintenance/__tests__/page.spec.tsx'

------
https://chatgpt.com/codex/tasks/task_e_68e29492c724832581ff82d3ca616412