### PR TITLE
feat: restore partner address lookup

### DIFF
--- a/mdm-platform/apps/web/src/app/(protected)/partners/new/page.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/partners/new/page.tsx
@@ -121,6 +121,17 @@ type LookupResult = {
   inscricao_estadual?: string;
 };
 
+type ViaCepResponse = {
+  cep?: string;
+  logradouro?: string;
+  complemento?: string;
+  bairro?: string;
+  localidade?: string;
+  uf?: string;
+  ibge?: string;
+  erro?: boolean;
+};
+
 const natureMatches = (natureza: string, targets: Array<'cliente' | 'fornecedor'>) => {
   return targets.some((target) => natureza === target || natureza === 'ambos');
 };
@@ -130,6 +141,8 @@ export default function NewPartner() {
   const [docLoading, setDocLoading] = useState(false);
   const [docError, setDocError] = useState<string | null>(null);
   const [submitError, setSubmitError] = useState<string | null>(null);
+  const [cepLoading, setCepLoading] = useState(false);
+  const [cepError, setCepError] = useState<string | null>(null);
 
   const {
     register,
@@ -174,37 +187,106 @@ export default function NewPartner() {
   const requiresFornecedor = useMemo(() => natureMatches(natureza, ['fornecedor']), [natureza]);
   const requiresCliente = useMemo(() => natureMatches(natureza, ['cliente']), [natureza]);
 
+  const setFieldIfEmpty = <K extends keyof FormValues>(
+    field: K,
+    value: FormValues[K],
+    options?: { shouldValidate?: boolean; shouldDirty?: boolean; shouldTouch?: boolean }
+  ) => {
+    if (value === undefined || value === null) {
+      return;
+    }
+
+    if (typeof value === "string" && !value.trim()) {
+      return;
+    }
+
+    const currentValue = watch(field);
+    const isEmpty =
+      currentValue === undefined ||
+      currentValue === null ||
+      (typeof currentValue === "string" ? !currentValue.trim() : false);
+
+    if (isEmpty) {
+      setValue(field, value, options);
+    }
+  };
+
   const applyLookupData = (data: LookupResult) => {
     if (!data) return;
     if (data.nome) {
-      setValue("nome_legal", data.nome, { shouldValidate: true });
+      setFieldIfEmpty("nome_legal", data.nome, { shouldValidate: true });
       if (tipoPessoa === "PF") {
-        setValue("contato_nome", data.nome, { shouldValidate: true });
+        setFieldIfEmpty("contato_nome", data.nome, { shouldValidate: true });
       }
     }
     if (data.email) {
-      replaceEmails([{ endereco: data.email, padrao: true }]);
-      setValue("contato_email", data.email, { shouldValidate: true });
+      const emailEntries = watch("comunicacao_emails");
+      const hasEmail = emailEntries?.some((entry) => entry?.endereco && entry.endereco.trim());
+      if (!hasEmail) {
+        replaceEmails([{ endereco: data.email, padrao: true }]);
+      }
+      setFieldIfEmpty("contato_email", data.email, { shouldValidate: true });
     }
     if (data.telefone) {
-      setValue("telefone", data.telefone);
-      if (!watch("contato_fone")) {
-        setValue("contato_fone", data.telefone);
-      }
+      setFieldIfEmpty("telefone", data.telefone);
+      setFieldIfEmpty("contato_fone", data.telefone);
     }
     if (data.inscricao_estadual) {
-      setValue("ie", data.inscricao_estadual);
+      setFieldIfEmpty("ie", data.inscricao_estadual);
     }
     if (data.endereco) {
       const { cep, logradouro, numero, complemento, bairro, municipio, municipio_ibge, uf } = data.endereco;
-      if (cep) setValue("cep", cep, { shouldValidate: true });
-      if (logradouro) setValue("logradouro", logradouro, { shouldValidate: true });
-      if (numero) setValue("numero", `${numero}`, { shouldValidate: true });
-      if (complemento) setValue("complemento", complemento);
-      if (bairro) setValue("bairro", bairro, { shouldValidate: true });
-      if (municipio) setValue("municipio", municipio.toUpperCase(), { shouldValidate: true });
-      if (municipio_ibge) setValue("municipio_ibge", `${municipio_ibge}`);
-      if (uf) setValue("uf", `${uf}`.toUpperCase().slice(0, 2), { shouldValidate: true });
+      if (cep) setFieldIfEmpty("cep", cep, { shouldValidate: true });
+      if (logradouro) setFieldIfEmpty("logradouro", logradouro, { shouldValidate: true });
+      if (numero) setFieldIfEmpty("numero", `${numero}`, { shouldValidate: true });
+      if (complemento) setFieldIfEmpty("complemento", complemento);
+      if (bairro) setFieldIfEmpty("bairro", bairro, { shouldValidate: true });
+      if (municipio) setFieldIfEmpty("municipio", municipio.toUpperCase(), { shouldValidate: true });
+      if (municipio_ibge) setFieldIfEmpty("municipio_ibge", `${municipio_ibge}`);
+      if (uf) setFieldIfEmpty("uf", `${uf}`.toUpperCase().slice(0, 2), { shouldValidate: true });
+    }
+  };
+
+  const handleLookupCep = async () => {
+    const cepValue = watch("cep") || "";
+    if (!cepValue.trim()) {
+      setCepError(null);
+      return;
+    }
+
+    if (!validateCEP(cepValue)) {
+      setCepError("Informe um CEP válido para buscar.");
+      return;
+    }
+
+    setCepError(null);
+    setCepLoading(true);
+
+    try {
+      const digits = onlyDigits(cepValue);
+      const response = await axios.get<ViaCepResponse>(`https://viacep.com.br/ws/${digits}/json/`);
+      const data = response.data;
+
+      if (!data || data.erro) {
+        setCepError("CEP não encontrado.");
+        return;
+      }
+
+      applyLookupData({
+        endereco: {
+          cep: data.cep,
+          logradouro: data.logradouro,
+          complemento: data.complemento,
+          bairro: data.bairro,
+          municipio: data.localidade,
+          municipio_ibge: data.ibge,
+          uf: data.uf
+        }
+      });
+    } catch (error) {
+      setCepError("Não foi possível buscar o CEP.");
+    } finally {
+      setCepLoading(false);
     }
   };
 
@@ -436,7 +518,94 @@ export default function NewPartner() {
             </div>
           </section>
 
-          {/* remaining sections unchanged */}          <section className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
+          <section className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
+            <h2 className="text-sm font-semibold uppercase tracking-wider text-zinc-500">Endereço fiscal</h2>
+            <div className="mt-4 grid gap-4 md:grid-cols-6">
+              <div className="md:col-span-3">
+                <label className="mb-1 block text-xs font-medium uppercase text-zinc-500">CEP</label>
+                <div className="flex gap-2">
+                  <input
+                    {...register("cep")}
+                    onBlur={handleLookupCep}
+                    placeholder="00000-000"
+                    className="flex-1 rounded-lg border border-zinc-200 px-3 py-2 text-sm"
+                  />
+                  <button
+                    type="button"
+                    onClick={handleLookupCep}
+                    disabled={cepLoading}
+                    className="rounded-lg border border-zinc-200 px-3 py-2 text-sm font-medium text-zinc-600 transition-colors disabled:cursor-not-allowed disabled:opacity-60 hover:border-zinc-300 hover:bg-zinc-50"
+                  >
+                    {cepLoading ? "Buscando..." : "Buscar CEP"}
+                  </button>
+                </div>
+                {renderError("cep")}
+                {cepError && <p className="mt-1 text-sm text-red-600">{cepError}</p>}
+              </div>
+              <div className="md:col-span-3">
+                <label className="mb-1 block text-xs font-medium uppercase text-zinc-500">Logradouro</label>
+                <input
+                  {...register("logradouro")}
+                  className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm"
+                  placeholder="Rua, avenida..."
+                />
+                {renderError("logradouro")}
+              </div>
+            </div>
+            <div className="mt-4 grid gap-4 md:grid-cols-6">
+              <div className="md:col-span-2">
+                <label className="mb-1 block text-xs font-medium uppercase text-zinc-500">Número</label>
+                <input
+                  {...register("numero")}
+                  className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm"
+                  placeholder="000"
+                />
+                {renderError("numero")}
+              </div>
+              <div className="md:col-span-4">
+                <label className="mb-1 block text-xs font-medium uppercase text-zinc-500">Complemento</label>
+                <input
+                  {...register("complemento")}
+                  className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm"
+                  placeholder="Apartamento, sala..."
+                />
+              </div>
+            </div>
+            <div className="mt-4 grid gap-4 md:grid-cols-6">
+              <div className="md:col-span-3">
+                <label className="mb-1 block text-xs font-medium uppercase text-zinc-500">Bairro</label>
+                <input
+                  {...register("bairro")}
+                  className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm"
+                  placeholder="Bairro"
+                />
+                {renderError("bairro")}
+              </div>
+              <div className="md:col-span-2">
+                <label className="mb-1 block text-xs font-medium uppercase text-zinc-500">Município</label>
+                <input
+                  {...register("municipio")}
+                  className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm"
+                  placeholder="Cidade"
+                />
+                {renderError("municipio")}
+              </div>
+              <div>
+                <label className="mb-1 block text-xs font-medium uppercase text-zinc-500">UF</label>
+                <input
+                  {...register("uf")}
+                  maxLength={2}
+                  className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm uppercase"
+                  placeholder="UF"
+                />
+                {renderError("uf")}
+              </div>
+            </div>
+            <input type="hidden" {...register("municipio_ibge")} />
+            {renderError("municipio_ibge")}
+          </section>
+
+          <section className="rounded-2xl border border-zinc-200 bg-white p-5 shadow-sm">
             <div className="flex items-center justify-between">
               <h2 className="text-sm font-semibold uppercase tracking-wider text-zinc-500">Comunicação</h2>
             </div>


### PR DESCRIPTION
## Summary
- reintroduce the fiscal address form section with registered CEP and location fields
- implement CEP lookup via ViaCEP and surface feedback without overwriting manual edits
- update document lookup population to respect user-provided values before filling defaults

## Testing
- pnpm --filter web lint *(fails: ESLint couldn't find an eslint.config file)*

------
https://chatgpt.com/codex/tasks/task_e_68e2947694508325819be48b274f0256