### PR TITLE
Fix memo dependency order in new partner page

### DIFF
--- a/mdm-platform/apps/web/src/app/(protected)/partners/new/page.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/partners/new/page.tsx
@@ -209,6 +209,9 @@ export default function NewPartner() {
   const banks = formValues?.banks ?? [];
   const transporters = formValues?.transportadores ?? [];
 
+  const requiresFornecedor = useMemo(() => natureMatches(natureza, ["fornecedor"]), [natureza]);
+  const requiresCliente = useMemo(() => natureMatches(natureza, ["cliente"]), [natureza]);
+
   const hasAnyError = (paths: string[]) => paths.some((path) => Boolean(getErrorAtPath(path)));
 
   const timelineSteps = useMemo(() => {
@@ -377,9 +380,6 @@ export default function NewPartner() {
     append: appendTransport,
     remove: removeTransport
   } = useFieldArray({ control, name: "transportadores" });
-
-  const requiresFornecedor = useMemo(() => natureMatches(natureza, ['fornecedor']), [natureza]);
-  const requiresCliente = useMemo(() => natureMatches(natureza, ['cliente']), [natureza]);
 
   const setFieldIfEmpty = <K extends keyof FormValues>(
     field: K,


### PR DESCRIPTION
## Summary
- move the requiresFornecedor and requiresCliente memo hooks before the timeline steps memo to avoid referencing undeclared variables

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e29c9048048325becebecbd6a2ccd3