### PR TITLE
feat(web): add unified create actions menu

### DIFF
--- a/mdm-platform/apps/web/src/app/(protected)/components/new-entity-menu.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/components/new-entity-menu.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useRouter } from "next/navigation";
+import { ChevronDown, Plus } from "lucide-react";
+
+type NewEntityMenuProps = {
+  className?: string;
+};
+
+type ActionOption = {
+  label: string;
+  description?: string;
+  href: string;
+};
+
+export function NewEntityMenu({ className }: NewEntityMenuProps) {
+  const router = useRouter();
+  const [open, setOpen] = useState(false);
+  const containerRef = useRef<HTMLDivElement | null>(null);
+
+  const options = useMemo<ActionOption[]>(
+    () => [
+      {
+        label: "Novo Parceiro",
+        description: "Cadastrar um novo parceiro",
+        href: "/partners/new"
+      },
+      {
+        label: "Nova solicitação de mudança",
+        description: "Criar alteração em parceiro existente",
+        href: "/partners/change-request"
+      },
+      {
+        label: "Nova auditoria",
+        description: "Disparar fluxo de auditoria de parceiros",
+        href: "/audit"
+      }
+    ],
+    []
+  );
+
+  useEffect(() => {
+    if (!open) return;
+
+    const handlePointerDown = (event: MouseEvent) => {
+      if (!containerRef.current?.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape") {
+        setOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handlePointerDown);
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("mousedown", handlePointerDown);
+      document.removeEventListener("keydown", handleKeyDown);
+    };
+  }, [open]);
+
+  const handleNavigate = (href: string) => {
+    setOpen(false);
+    router.push(href);
+  };
+
+  const containerClasses = [
+    "relative",
+    "inline-flex",
+    "items-stretch",
+    "overflow-hidden",
+    "rounded-lg",
+    "border",
+    "border-zinc-200",
+    "bg-white",
+    "shadow-sm"
+  ];
+
+  if (className) {
+    containerClasses.push(className);
+  }
+
+  return (
+    <div ref={containerRef} className={containerClasses.join(" ")}>
+      <button
+        type="button"
+        onClick={() => handleNavigate("/partners/new")}
+        className="inline-flex items-center gap-2 bg-zinc-900 px-4 py-2 text-sm font-semibold text-white transition hover:bg-zinc-800"
+      >
+        <Plus size={16} />
+        <span>Novo</span>
+      </button>
+      <button
+        type="button"
+        aria-label="Abrir opções de criação"
+        onClick={() => setOpen((value) => !value)}
+        className="inline-flex items-center justify-center bg-zinc-900 px-2 text-white transition hover:bg-zinc-800"
+      >
+        <ChevronDown size={16} />
+      </button>
+      {open ? (
+        <div className="absolute right-0 top-full z-50 mt-2 w-60 overflow-hidden rounded-lg border border-zinc-200 bg-white shadow-xl">
+          <ul className="flex flex-col py-2">
+            {options.map((option) => (
+              <li key={option.href}>
+                <button
+                  type="button"
+                  onClick={() => handleNavigate(option.href)}
+                  className="flex w-full flex-col items-start gap-0.5 px-4 py-2 text-left transition hover:bg-zinc-50"
+                >
+                  <span className="text-sm font-semibold text-zinc-900">{option.label}</span>
+                  {option.description ? (
+                    <span className="text-xs text-zinc-500">{option.description}</span>
+                  ) : null}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export default NewEntityMenu;

--- a/mdm-platform/apps/web/src/app/(protected)/dashboard/page.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/dashboard/page.tsx
@@ -4,6 +4,7 @@ import axios from "axios";
 import { useRouter } from "next/navigation";
 import { PartnerApprovalStage } from "@mdm/types";
 import { getStoredUser } from "../../../lib/auth";
+import { NewEntityMenu } from "../components/new-entity-menu";
 
 const statusLabels: Record<string, string> = {
   draft: "Rascunhos",
@@ -136,10 +137,13 @@ export default function Dashboard() {
 
   return (
     <main className="flex min-h-screen flex-col gap-6 bg-zinc-100 p-6">
-      <header>
-        <h1 className="text-2xl font-semibold text-zinc-900">Dashboard</h1>
-        <p className="text-sm text-zinc-500">Acompanhe o andamento dos cadastros de parceiros.</p>
-      </header>
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <header className="space-y-1">
+          <h1 className="text-2xl font-semibold text-zinc-900">Dashboard</h1>
+          <p className="text-sm text-zinc-500">Acompanhe o andamento dos cadastros de parceiros.</p>
+        </header>
+        <NewEntityMenu className="self-start md:self-auto" />
+      </div>
 
       {loading ? (
         <div className="grid gap-4 md:grid-cols-2 xl:grid-cols-4">

--- a/mdm-platform/apps/web/src/app/(protected)/layout.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/layout.tsx
@@ -1,7 +1,7 @@
 ﻿"use client";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { Home, Users, PlusSquare, LogOut, Bell, UserCog, Clock3, ShieldCheck } from "lucide-react";
+import { Home, Users, LogOut, Bell, UserCog, Clock3, ShieldCheck } from "lucide-react";
 import { PropsWithChildren, useEffect, useMemo, useState } from "react";
 import { jwtDecode } from "jwt-decode";
 import { getStoredUser, storeUser, StoredUser } from "../../lib/auth";
@@ -18,7 +18,6 @@ type TokenPayload = {
 const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: Home },
   { href: "/partners", label: "Parceiros", icon: Users },
-  { href: "/partners/new", label: "Novo", icon: PlusSquare },
   { href: "/notifications", label: "Notificações", icon: Bell },
   { href: "/audit", label: "Auditoria", icon: ShieldCheck },
   { href: "/user-maintenance", label: "Usuários", icon: UserCog },

--- a/mdm-platform/apps/web/src/app/(protected)/partners/page.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/partners/page.tsx
@@ -6,6 +6,7 @@ import { useRouter } from "next/navigation";
 import { PartnerApprovalStage } from "@mdm/types";
 import { getStoredUser, StoredUser } from "../../../lib/auth";
 import { mapSapSegments, summarizeSapOverall } from "./sap-integration-helpers";
+import { NewEntityMenu } from "../components/new-entity-menu";
 
 const stageLabels: Record<PartnerApprovalStage, string> = {
   fiscal: "Fiscal",
@@ -373,19 +374,22 @@ export default function PartnersList() {
       <section className="flex flex-col gap-3">
         <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
           <h1 className="text-2xl font-semibold text-zinc-900">Parceiros</h1>
-          <div className="flex items-center gap-2">
-            <div className="relative">
-              <input
-                value={search}
-                onChange={(event) => setSearch(event.target.value)}
-                placeholder="Buscar por nome, documento, ID SAP ou MDM"
-                className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm md:w-80"
-              />
-            </div>
+          <NewEntityMenu className="self-start md:self-auto" />
+        </div>
+        <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+          <div className="relative w-full sm:w-auto sm:flex-1 md:flex-initial">
+            <input
+              value={search}
+              onChange={(event) => setSearch(event.target.value)}
+              placeholder="Buscar por nome, documento, ID SAP ou MDM"
+              className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm md:w-80"
+            />
+          </div>
+          <div className="flex items-center justify-end gap-2">
             <button
               type="button"
               onClick={() => setShowColumnPicker((value) => !value)}
-              className="rounded-lg border border-zinc-200 px-3 py-2 text-sm font-medium text-zinc-600 hover:border-zinc-300 hover:bg-zinc-50"
+              className="rounded-lg border border-zinc-200 px-3 py-2 text-sm font-medium text-zinc-600 transition-colors hover:border-zinc-300 hover:bg-zinc-50"
             >
               ⚙
             </button>


### PR DESCRIPTION
## Summary
- remove the legacy sidebar "Novo" link and replace it with a shared actions menu
- add a reusable split-button to start new partner, change request, or audit flows
- surface the new action menu on the dashboard header and above the partners table

## Testing
- pnpm --filter @mdm/web dev

------
https://chatgpt.com/codex/tasks/task_e_68e2c29ddfec832583f8b4a43bf3a322