### PR TITLE
Refactor partner schema composition

### DIFF
--- a/mdm-platform/apps/web/src/app/(protected)/partners/new/page.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/partners/new/page.tsx
@@ -106,10 +106,17 @@ const createSchema = (tipo: "PJ" | "PF") => {
     });
 };
 
-  if (data.ie && !validateIE(data.ie, { allowIsento: true })) {
-    ctx.addIssue({ code: z.ZodIssueCode.custom, path: ["ie"], message: "Inscrição estadual inválida" });
-  }
-});
+const schema = z
+  .discriminatedUnion("tipo_pessoa", [createSchema("PJ"), createSchema("PF")])
+  .superRefine((data, ctx) => {
+    if (data.ie && !validateIE(data.ie, { allowIsento: true })) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ["ie"],
+        message: "Inscrição estadual inválida"
+      });
+    }
+  });
 
 type FormValues = z.infer<typeof schema>;
 


### PR DESCRIPTION
## Summary
- add a shared schema instance combining PJ and PF variants with discriminated union
- move IE validation logic into a superRefine on the unified schema
- ensure form resolver and types rely on the consolidated schema constant

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2ac9e44688325a854a29a3b31ced9