### PR TITLE
feat: enhance partner audit management

### DIFF
--- a/mdm-platform/apps/web/src/app/(protected)/audit/components/job-list.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/audit/components/job-list.tsx
@@ -1,0 +1,258 @@
+"use client";
+
+import { AlertTriangle, CircleSlash, Loader2, RefreshCw, RotateCcw } from "lucide-react";
+
+import { AuditJobWithMetadata } from "../types";
+import {
+  formatDateTime,
+  formatJobResult,
+  isFinalStatus,
+  normalizeText,
+  resolveOriginLabel,
+  resolveStatusLabel,
+  resolveStatusTone
+} from "../utils";
+
+type AuditJobListProps = {
+  jobs: AuditJobWithMetadata[];
+  refreshingJobs: string[];
+  reprocessingJobs: string[];
+  cancelingJobs: string[];
+  onRefresh: (job: AuditJobWithMetadata) => void;
+  onReprocess?: (job: AuditJobWithMetadata) => void;
+  onCancel?: (job: AuditJobWithMetadata) => void;
+};
+
+export function AuditJobTable({
+  jobs,
+  refreshingJobs,
+  reprocessingJobs,
+  cancelingJobs,
+  onRefresh,
+  onReprocess,
+  onCancel
+}: AuditJobListProps) {
+  if (jobs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="hidden overflow-hidden rounded-2xl border border-zinc-200 bg-white md:block">
+      <table className="min-w-full divide-y divide-zinc-200 text-sm">
+        <thead className="bg-zinc-50 text-xs uppercase tracking-wide text-zinc-500">
+          <tr>
+            <th className="px-4 py-3 text-left font-medium">Job</th>
+            <th className="px-4 py-3 text-left font-medium">Parceiros</th>
+            <th className="px-4 py-3 text-left font-medium">Origem</th>
+            <th className="px-4 py-3 text-left font-medium">Status</th>
+            <th className="px-4 py-3 text-left font-medium">Solicitado por</th>
+            <th className="px-4 py-3 text-left font-medium">Criado em</th>
+            <th className="px-4 py-3 text-left font-medium">Atualizado</th>
+            <th className="px-4 py-3 text-left font-medium">Resultado</th>
+            <th className="px-4 py-3 text-right font-medium">Ações</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-zinc-200">
+          {jobs.map((job) => {
+            const statusTone = resolveStatusTone(job.status);
+            const normalizedStatus = resolveStatusLabel(job.status);
+            const normalizedStatusKey = normalizeText(job.status);
+            const isRefreshing = refreshingJobs.includes(job.jobId);
+            const isReprocessing = reprocessingJobs.includes(job.jobId);
+            const isCanceling = cancelingJobs.includes(job.jobId);
+            const finalStatus = isFinalStatus(job.status);
+            const showReprocess = typeof onReprocess === "function";
+            const canReprocess = finalStatus;
+            const showCancel = typeof onCancel === "function" && !finalStatus;
+
+            return (
+              <tr key={job.jobId} className="hover:bg-zinc-50">
+                <td className="px-4 py-3 font-mono text-xs text-zinc-600">{job.jobId}</td>
+                <td className="px-4 py-3">
+                  <div className="flex flex-wrap gap-2">
+                    {job.partnerIds.length > 0 ? (
+                      job.partnerIds.map((id) => (
+                        <span key={id} className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-xs text-zinc-600">
+                          {id}
+                        </span>
+                      ))
+                    ) : (
+                      <span className="text-xs text-zinc-400">Não informado</span>
+                    )}
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-sm text-zinc-600">{resolveOriginLabel(job.origin)}</td>
+                <td className="px-4 py-3">
+                  <div className="flex flex-col gap-1">
+                    <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-xs font-semibold ${statusTone}`}>
+                      {normalizedStatus}
+                    </span>
+                    {job.error ? <span className="text-xs text-red-600">{job.error}</span> : null}
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-sm text-zinc-600">{job.requestedBy ?? "-"}</td>
+                <td className="px-4 py-3 text-sm text-zinc-600">{formatDateTime(job.createdAt)}</td>
+                <td className="px-4 py-3 text-sm text-zinc-600">
+                  {job.completedAt
+                    ? formatDateTime(job.completedAt)
+                    : job.lastCheckedAt
+                    ? formatDateTime(job.lastCheckedAt)
+                    : "-"}
+                </td>
+                <td className="px-4 py-3 text-sm text-zinc-600">
+                  <div className="flex flex-col gap-1">
+                    <span>{formatJobResult(job.result)}</span>
+                    {normalizedStatusKey === "failed" || normalizedStatusKey === "erro" || normalizedStatusKey === "error" ? (
+                      <span className="text-xs text-zinc-400">Considere reprocessar a auditoria.</span>
+                    ) : null}
+                  </div>
+                </td>
+                <td className="px-4 py-3 text-right">
+                  <div className="flex items-center justify-end gap-2">
+                    <button
+                      type="button"
+                      onClick={() => onRefresh(job)}
+                      className="inline-flex items-center gap-1 rounded-lg border border-zinc-200 px-2 py-1 text-xs font-medium text-zinc-600 transition hover:border-zinc-300 hover:text-zinc-900"
+                      disabled={isRefreshing}
+                    >
+                      {isRefreshing ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
+                      Atualizar
+                    </button>
+                    {showReprocess ? (
+                      <button
+                        type="button"
+                        onClick={() => onReprocess?.(job)}
+                        className="inline-flex items-center gap-1 rounded-lg border border-indigo-200 px-2 py-1 text-xs font-medium text-indigo-600 transition hover:border-indigo-300 hover:text-indigo-900 disabled:opacity-60"
+                        disabled={isReprocessing || !canReprocess}
+                      >
+                        {isReprocessing ? <Loader2 className="h-3 w-3 animate-spin" /> : <RotateCcw className="h-3 w-3" />}
+                        Reprocessar
+                      </button>
+                    ) : null}
+                    {showCancel ? (
+                      <button
+                        type="button"
+                        onClick={() => onCancel?.(job)}
+                        className="inline-flex items-center gap-1 rounded-lg border border-red-200 px-2 py-1 text-xs font-medium text-red-600 transition hover:border-red-300 hover:text-red-700 disabled:opacity-60"
+                        disabled={isCanceling}
+                      >
+                        {isCanceling ? <Loader2 className="h-3 w-3 animate-spin" /> : <CircleSlash className="h-3 w-3" />}
+                        Cancelar
+                      </button>
+                    ) : null}
+                  </div>
+                </td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+export function AuditJobCards({
+  jobs,
+  refreshingJobs,
+  reprocessingJobs,
+  cancelingJobs,
+  onRefresh,
+  onReprocess,
+  onCancel
+}: AuditJobListProps) {
+  if (jobs.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="grid gap-3 md:hidden">
+      {jobs.map((job) => {
+        const statusTone = resolveStatusTone(job.status);
+        const statusLabel = resolveStatusLabel(job.status);
+        const normalizedStatusKey = normalizeText(job.status);
+        const isRefreshing = refreshingJobs.includes(job.jobId);
+        const isReprocessing = reprocessingJobs.includes(job.jobId);
+        const isCanceling = cancelingJobs.includes(job.jobId);
+        const finalStatus = isFinalStatus(job.status);
+        const showReprocess = typeof onReprocess === "function";
+        const canReprocess = finalStatus;
+        const showCancel = typeof onCancel === "function" && !finalStatus;
+
+        return (
+          <article key={job.jobId} className="rounded-2xl border border-zinc-200 bg-white p-4 shadow-sm">
+            <div className="flex items-center justify-between gap-3">
+              <div className="font-mono text-xs text-zinc-500">{job.jobId}</div>
+              <div className="flex items-center gap-2">
+                <button
+                  type="button"
+                  onClick={() => onRefresh(job)}
+                  className="inline-flex items-center gap-1 rounded-lg border border-zinc-200 px-2 py-1 text-[11px] font-medium text-zinc-600 transition hover:border-zinc-300 hover:text-zinc-900"
+                  disabled={isRefreshing}
+                >
+                  {isRefreshing ? <Loader2 className="h-3 w-3 animate-spin" /> : <RefreshCw className="h-3 w-3" />}
+                  Atualizar
+                </button>
+                {showReprocess ? (
+                  <button
+                    type="button"
+                    onClick={() => onReprocess(job)}
+                    className="inline-flex items-center gap-1 rounded-lg border border-indigo-200 px-2 py-1 text-[11px] font-medium text-indigo-600 transition hover:border-indigo-300 hover:text-indigo-900 disabled:opacity-60"
+                    disabled={isReprocessing || !canReprocess}
+                  >
+                    {isReprocessing ? <Loader2 className="h-3 w-3 animate-spin" /> : <RotateCcw className="h-3 w-3" />}
+                    Reprocessar
+                  </button>
+                ) : null}
+                {showCancel ? (
+                  <button
+                    type="button"
+                    onClick={() => onCancel?.(job)}
+                    className="inline-flex items-center gap-1 rounded-lg border border-red-200 px-2 py-1 text-[11px] font-medium text-red-600 transition hover:border-red-300 hover:text-red-700 disabled:opacity-60"
+                    disabled={isCanceling}
+                  >
+                    {isCanceling ? <Loader2 className="h-3 w-3 animate-spin" /> : <CircleSlash className="h-3 w-3" />}
+                    Cancelar
+                  </button>
+                ) : null}
+              </div>
+            </div>
+            <div className="mt-3 flex flex-wrap gap-2">
+              {job.partnerIds.length > 0 ? (
+                job.partnerIds.map((id) => (
+                  <span key={id} className="inline-flex items-center rounded-full bg-zinc-100 px-2 py-0.5 text-[11px] text-zinc-600">
+                    {id}
+                  </span>
+                ))
+              ) : (
+                <span className="text-xs text-zinc-400">Parceiros não informados</span>
+              )}
+            </div>
+            <div className="mt-3 flex flex-col gap-1 text-xs text-zinc-500">
+              <div>
+                <span className={`inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-semibold ${statusTone}`}>
+                  {statusLabel}
+                </span>
+              </div>
+              <div>Origem: {resolveOriginLabel(job.origin)}</div>
+              <div>Solicitado por: {job.requestedBy ?? "-"}</div>
+              <div>Criado em: {formatDateTime(job.createdAt)}</div>
+              <div>
+                Última atualização: {job.completedAt ? formatDateTime(job.completedAt) : job.lastCheckedAt ? formatDateTime(job.lastCheckedAt) : "-"}
+              </div>
+              <div>Resultado: {formatJobResult(job.result)}</div>
+              {job.error ? (
+                <div className="flex items-start gap-1 text-red-600">
+                  <AlertTriangle className="mt-[2px] h-3 w-3" />
+                  <span>{job.error}</span>
+                </div>
+              ) : null}
+              {normalizedStatusKey === "failed" || normalizedStatusKey === "erro" || normalizedStatusKey === "error" ? (
+                <div className="text-[11px] text-zinc-400">Considere reprocessar a auditoria.</div>
+              ) : null}
+            </div>
+          </article>
+        );
+      })}
+    </div>
+  );
+}

--- a/mdm-platform/apps/web/src/app/(protected)/audit/types.ts
+++ b/mdm-platform/apps/web/src/app/(protected)/audit/types.ts
@@ -1,0 +1,5 @@
+import { AuditJob } from "./audit-service";
+
+export type AuditJobWithMetadata = AuditJob & {
+  lastCheckedAt?: string | null;
+};

--- a/mdm-platform/apps/web/src/app/(protected)/audit/utils.ts
+++ b/mdm-platform/apps/web/src/app/(protected)/audit/utils.ts
@@ -1,0 +1,111 @@
+const FINAL_STATUSES = new Set([
+  "completed",
+  "concluido",
+  "concluído",
+  "sucesso",
+  "success",
+  "failed",
+  "erro",
+  "error",
+  "cancelled",
+  "canceled"
+]);
+
+const STATUS_LABELS: Record<string, string> = {
+  pending: "Pendente",
+  queued: "Na fila",
+  running: "Em processamento",
+  processing: "Em processamento",
+  completed: "Concluído",
+  concluido: "Concluído",
+  "concluído": "Concluído",
+  sucesso: "Concluído",
+  success: "Concluído",
+  failed: "Falhou",
+  erro: "Falhou",
+  error: "Falhou",
+  cancelled: "Cancelado",
+  canceled: "Cancelado"
+};
+
+const STATUS_TONES: Record<string, string> = {
+  completed: "border-emerald-200 bg-emerald-50 text-emerald-700",
+  concluido: "border-emerald-200 bg-emerald-50 text-emerald-700",
+  "concluído": "border-emerald-200 bg-emerald-50 text-emerald-700",
+  sucesso: "border-emerald-200 bg-emerald-50 text-emerald-700",
+  success: "border-emerald-200 bg-emerald-50 text-emerald-700",
+  running: "border-indigo-200 bg-indigo-50 text-indigo-700",
+  processing: "border-indigo-200 bg-indigo-50 text-indigo-700",
+  pending: "border-amber-200 bg-amber-50 text-amber-700",
+  queued: "border-amber-200 bg-amber-50 text-amber-700",
+  failed: "border-red-200 bg-red-50 text-red-700",
+  erro: "border-red-200 bg-red-50 text-red-700",
+  error: "border-red-200 bg-red-50 text-red-700",
+  cancelled: "border-zinc-200 bg-zinc-50 text-zinc-600",
+  canceled: "border-zinc-200 bg-zinc-50 text-zinc-600"
+};
+
+const ORIGIN_LABELS: Record<string, string> = {
+  individual: "Individual",
+  bulk: "Em massa"
+};
+
+export function normalizeText(value: string | null | undefined) {
+  return value ? value.toLowerCase() : "";
+}
+
+export function isFinalStatus(status: string | null | undefined) {
+  const normalized = normalizeText(status);
+  return normalized ? FINAL_STATUSES.has(normalized) : false;
+}
+
+export function resolveStatusLabel(status: string | null | undefined) {
+  const normalized = normalizeText(status);
+  if (!normalized) return "Indefinido";
+  return STATUS_LABELS[normalized] ?? status ?? "Indefinido";
+}
+
+export function resolveStatusTone(status: string | null | undefined) {
+  const normalized = normalizeText(status);
+  if (normalized && STATUS_TONES[normalized]) {
+    return STATUS_TONES[normalized];
+  }
+  return "border-zinc-200 bg-zinc-50 text-zinc-600";
+}
+
+export function resolveOriginLabel(origin: string | null | undefined) {
+  const normalized = normalizeText(origin);
+  if (!normalized) return "Não informado";
+  return ORIGIN_LABELS[normalized] ?? origin ?? "Não informado";
+}
+
+export function formatDateTime(value: string | null | undefined) {
+  if (!value) return "-";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) {
+    return value;
+  }
+  return date.toLocaleString("pt-BR", {
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit"
+  });
+}
+
+export function formatJobResult(value: unknown) {
+  if (value === null || value === undefined) {
+    return "-";
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+  try {
+    return JSON.stringify(value);
+  } catch (error) {
+    return String(value);
+  }
+}
+
+export { FINAL_STATUSES };

--- a/mdm-platform/apps/web/src/app/(protected)/layout.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/layout.tsx
@@ -20,7 +20,7 @@ const navItems = [
   { href: "/partners", label: "Parceiros", icon: Users },
   { href: "/change-requests", label: "Solicitações", icon: FileDiff },
   { href: "/notifications", label: "Notificações", icon: Bell },
-  { href: "/audit", label: "Auditoria", icon: ShieldCheck },
+  { href: "/audit", label: "Auditorias", icon: ShieldCheck },
   { href: "/user-maintenance", label: "Usuários", icon: UserCog },
   { href: "/history", label: "Histórico", icon: Clock3 }
 ];


### PR DESCRIPTION
## Summary
- add shared audit utilities, metadata types, and responsive job list components for table/card layouts
- update the audit page to drive individual/bulk requests, filtering, and new reprocess/cancel actions using the shared components
- extend the audit service with reprocess/cancel endpoints, cover them with tests, and rename the sidebar entry to "Auditorias"

## Testing
- `pnpm vitest --run "apps/web/src/app/(protected)/audit/audit-service.spec.ts"`


------
https://chatgpt.com/codex/tasks/task_e_68e2c8449bec8325b4a5132143773ebe