### PR TITLE
Fix Next path aliases for change request pages

### DIFF
--- a/mdm-platform/apps/web/tsconfig.json
+++ b/mdm-platform/apps/web/tsconfig.json
@@ -25,8 +25,11 @@
     "baseUrl": ".",
     "paths": {
       "@mdm/utils": ["../../packages/utils/src"],
+      "@mdm/utils/*": ["../../packages/utils/src/*"],
       "@mdm/types": ["../../packages/types/src"],
-      "@mdm/ui": ["../../packages/ui/src"]
+      "@mdm/types/*": ["../../packages/types/src/*"],
+      "@mdm/ui": ["../../packages/ui/src"],
+      "@mdm/ui/*": ["../../packages/ui/src/*"]
     },
     "plugins": [
       {


### PR DESCRIPTION
## Summary
- add wildcard path aliases for shared workspace packages in the web tsconfig so Next.js can resolve deep imports

## Testing
- pnpm --filter @mdm/web dev

------
https://chatgpt.com/codex/tasks/task_e_68e2d61c84b0832591c1622376bbf146