### PR TITLE
Improve partner onboarding UX and expose change request hub

### DIFF
--- a/mdm-platform/apps/web/src/app/(protected)/change-requests/page.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/change-requests/page.tsx
@@ -1,0 +1,97 @@
+"use client";
+
+import { useRouter } from "next/navigation";
+import { useState } from "react";
+
+const modeOptions = [
+  {
+    key: "individual" as const,
+    title: "Solicitação individual",
+    description: "Indique um parceiro específico para solicitar alterações pontuais."
+  },
+  {
+    key: "massa" as const,
+    title: "Solicitação em massa",
+    description: "Prepare uma solicitação para vários parceiros a partir de uma planilha ou lista de códigos."
+  }
+];
+
+type ModeKey = typeof modeOptions[number]["key"];
+
+export default function ChangeRequestsHome() {
+  const router = useRouter();
+  const [partnerCode, setPartnerCode] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const navigateToWizard = (mode: ModeKey) => {
+    const trimmed = partnerCode.trim();
+    if (!trimmed) {
+      setError("Informe o código do parceiro que deseja alterar.");
+      return;
+    }
+    const params = new URLSearchParams({ partner: trimmed });
+    if (mode === "massa") {
+      params.set("mode", "massa");
+    }
+    router.push(`/partners/change-request?${params.toString()}`);
+  };
+
+  return (
+    <main className="min-h-screen bg-zinc-100 p-6">
+      <div className="mx-auto flex w-full max-w-4xl flex-col gap-6">
+        <header className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm">
+          <h1 className="text-2xl font-semibold text-zinc-900">Solicitações de mudança</h1>
+          <p className="mt-2 text-sm text-zinc-500">
+            Informe o parceiro que deseja atualizar e escolha o tipo de solicitação para continuar.
+          </p>
+          <div className="mt-5 flex flex-col gap-2 md:flex-row md:items-end">
+            <div className="flex-1">
+              <label htmlFor="partner-code" className="mb-1 block text-xs font-semibold uppercase tracking-wide text-zinc-500">
+                Código do parceiro
+              </label>
+              <input
+                id="partner-code"
+                value={partnerCode}
+                onChange={(event) => {
+                  setPartnerCode(event.target.value);
+                  if (error) {
+                    setError(null);
+                  }
+                }}
+                placeholder="Ex.: PARC12345"
+                className="w-full rounded-lg border border-zinc-200 px-3 py-2 text-sm"
+              />
+            </div>
+          </div>
+          {error ? <p className="mt-2 text-sm text-red-600">{error}</p> : null}
+        </header>
+
+        <section className="grid gap-4 md:grid-cols-2">
+          {modeOptions.map((option) => (
+            <article key={option.key} className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm">
+              <h2 className="text-lg font-semibold text-zinc-900">{option.title}</h2>
+              <p className="mt-2 text-sm text-zinc-500">{option.description}</p>
+              <button
+                type="button"
+                onClick={() => navigateToWizard(option.key)}
+                className="mt-4 inline-flex w-full items-center justify-center rounded-lg bg-zinc-900 px-3 py-2 text-sm font-semibold text-white transition-opacity hover:opacity-90"
+              >
+                Continuar
+              </button>
+            </article>
+          ))}
+        </section>
+
+        <section className="rounded-2xl border border-zinc-200 bg-white p-6 shadow-sm text-sm text-zinc-600">
+          <h3 className="text-base font-semibold text-zinc-900">Acompanhar solicitações existentes</h3>
+          <p className="mt-2">
+            Após criar uma solicitação, utilize o histórico na tela do parceiro para acompanhar aprovações, anexar documentos e consultar o status atual.
+          </p>
+          <p className="mt-2">
+            Para solicitações em massa, utilize a aba "+Solicitações existentes" dentro do assistente para visualizar o andamento das mudanças enviadas.
+          </p>
+        </section>
+      </div>
+    </main>
+  );
+}

--- a/mdm-platform/apps/web/src/app/(protected)/layout.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/layout.tsx
@@ -1,7 +1,7 @@
 ﻿"use client";
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { Home, Users, PlusSquare, LogOut, Bell, UserCog, Clock3, ShieldCheck } from "lucide-react";
+import { Home, Users, PlusSquare, LogOut, Bell, UserCog, Clock3, ShieldCheck, ClipboardList } from "lucide-react";
 import { PropsWithChildren, useEffect, useMemo, useState } from "react";
 import { jwtDecode } from "jwt-decode";
 import { getStoredUser, storeUser, StoredUser } from "../../lib/auth";
@@ -18,6 +18,7 @@ type TokenPayload = {
 const navItems = [
   { href: "/dashboard", label: "Dashboard", icon: Home },
   { href: "/partners", label: "Parceiros", icon: Users },
+  { href: "/change-requests", label: "Solicitações", icon: ClipboardList },
   { href: "/partners/new", label: "Novo", icon: PlusSquare },
   { href: "/notifications", label: "Notificações", icon: Bell },
   { href: "/audit", label: "Auditoria", icon: ShieldCheck },

--- a/mdm-platform/apps/web/src/app/(protected)/partners/change-request/page.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/partners/change-request/page.tsx
@@ -182,7 +182,9 @@ export default function ChangeRequestPage() {
   const searchParams = useSearchParams();
   const partnerId = searchParams.get("partner");
 
-  const [mode, setMode] = useState<Mode>("individual");
+  const modeParam = searchParams.get("mode");
+  const initialMode: Mode = modeParam === "massa" ? "massa" : "individual";
+  const [mode, setMode] = useState<Mode>(initialMode);
   const [origin, setOrigin] = useState<(typeof originOptions)[number]["value"]>(originOptions[0]?.value ?? "interno");
   const [fields, setFields] = useState(buildEmptyFieldState);
   const [fieldErrors, setFieldErrors] = useState(buildEmptyFieldErrors);
@@ -207,6 +209,10 @@ export default function ChangeRequestPage() {
     () => parseBulkInput(bulkInput, mode === "massa" ? partnerId : undefined),
     [bulkInput, mode, partnerId]
   );
+
+  useEffect(() => {
+    setMode(initialMode);
+  }, [initialMode]);
 
   const loadPartner = useCallback(async () => {
     if (!partnerId) {
@@ -558,6 +564,23 @@ export default function ChangeRequestPage() {
     return (
       <main className="flex min-h-screen items-center justify-center bg-zinc-100 p-6 text-sm text-zinc-600">
         Carregando parceiro...
+      </main>
+    );
+  }
+
+  if (partnerError && !partnerId) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-zinc-100 p-6">
+        <div className="flex flex-col gap-4 rounded-lg border border-amber-200 bg-amber-50 px-5 py-4 text-sm text-amber-700">
+          <p>{partnerError}</p>
+          <button
+            type="button"
+            onClick={() => router.push("/change-requests")}
+            className="self-start rounded-lg border border-amber-300 px-3 py-1 text-xs font-medium text-amber-700 transition-colors hover:border-amber-400 hover:bg-amber-100"
+          >
+            Voltar para solicitações
+          </button>
+        </div>
       </main>
     );
   }


### PR DESCRIPTION
## Summary
- restructure the partner creation flow with contact validation, modal management, and automatic CEP lookup
- add a change request landing screen and navigation entry that routes to the existing wizard with the correct mode
- update the wizard to respect the mode query parameter and provide a friendly fallback when no partner code is supplied

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e1aa334f4c8325ba7dd233150e611a