### PR TITLE
feat: add partner draft lifecycle and dashboard integration

### DIFF
--- a/mdm-platform/apps/api/src/modules/partners/__tests__/audit-logs.spec.ts
+++ b/mdm-platform/apps/api/src/modules/partners/__tests__/audit-logs.spec.ts
@@ -30,6 +30,13 @@ describe("PartnersService audit processing", () => {
     create: vi.fn(),
     save: vi.fn()
   };
+  const draftRepo = {
+    create: vi.fn(),
+    save: vi.fn(),
+    find: vi.fn(),
+    findOne: vi.fn(),
+    delete: vi.fn()
+  };
   const sapIntegration = {
     integratePartner: vi.fn(),
     retry: vi.fn(),
@@ -50,6 +57,11 @@ describe("PartnersService audit processing", () => {
     noteRepo.find.mockReset();
     noteRepo.create.mockReset();
     noteRepo.save.mockReset();
+    draftRepo.create.mockReset();
+    draftRepo.save.mockReset();
+    draftRepo.find.mockReset();
+    draftRepo.findOne.mockReset();
+    draftRepo.delete.mockReset();
 
     sapIntegration.integratePartner.mockReset();
     sapIntegration.retry.mockReset();
@@ -61,6 +73,7 @@ describe("PartnersService audit processing", () => {
       auditJobRepo as any,
       auditLogRepo as any,
       noteRepo as any,
+      draftRepo as any,
       sapIntegration as any
     );
   });

--- a/mdm-platform/apps/api/src/modules/partners/__tests__/document-validation.spec.ts
+++ b/mdm-platform/apps/api/src/modules/partners/__tests__/document-validation.spec.ts
@@ -85,6 +85,7 @@ describe("PartnersService lookup", () => {
   const auditJobRepo = { findOne: vi.fn(), update: vi.fn() };
   const auditLogRepo = { save: vi.fn() };
   const noteRepo = { find: vi.fn(), create: vi.fn(), save: vi.fn() };
+  const draftRepo = { create: vi.fn(), save: vi.fn(), find: vi.fn(), findOne: vi.fn(), delete: vi.fn() };
   const sapIntegration = {
     integratePartner: vi.fn().mockResolvedValue({ segments: [], completed: true, updates: {} }),
     retry: vi.fn().mockResolvedValue({ segments: [], completed: true, updates: {} }),
@@ -99,6 +100,11 @@ describe("PartnersService lookup", () => {
     noteRepo.find.mockReset();
     noteRepo.create.mockReset();
     noteRepo.save.mockReset();
+    draftRepo.create.mockReset();
+    draftRepo.save.mockReset();
+    draftRepo.find.mockReset();
+    draftRepo.findOne.mockReset();
+    draftRepo.delete.mockReset();
     sapIntegration.integratePartner.mockReset();
     sapIntegration.retry.mockReset();
     sapIntegration.markSegmentsAsError.mockClear();
@@ -108,6 +114,7 @@ describe("PartnersService lookup", () => {
       auditJobRepo as any,
       auditLogRepo as any,
       noteRepo as any,
+      draftRepo as any,
       sapIntegration as any
     );
   });

--- a/mdm-platform/apps/api/src/modules/partners/__tests__/drafts.spec.ts
+++ b/mdm-platform/apps/api/src/modules/partners/__tests__/drafts.spec.ts
@@ -1,0 +1,114 @@
+import "reflect-metadata";
+import { ForbiddenException, NotFoundException, UnauthorizedException } from "@nestjs/common";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { PartnersService } from "../partners.service";
+
+vi.mock("../entities/partner.entity", () => ({ Partner: class {} }));
+vi.mock("../entities/partner-change-request.entity", () => ({ PartnerChangeRequest: class {} }));
+vi.mock("../entities/partner-audit-job.entity", () => ({ PartnerAuditJob: class {} }));
+vi.mock("../entities/partner-audit-log.entity", () => ({ PartnerAuditLog: class {} }));
+vi.mock("../entities/partner-note.entity", () => ({ PartnerNote: class {} }));
+vi.mock("../entities/partner-draft.entity", () => ({ PartnerDraft: class {} }));
+
+describe("PartnersService drafts", () => {
+  const repo = { findOne: vi.fn(), create: vi.fn(), save: vi.fn() };
+  const changeRepo = { find: vi.fn(), save: vi.fn() };
+  const auditJobRepo = { findOne: vi.fn(), update: vi.fn() };
+  const auditLogRepo = { save: vi.fn() };
+  const noteRepo = { find: vi.fn(), create: vi.fn(), save: vi.fn() };
+  const draftRepo = {
+    create: vi.fn(),
+    save: vi.fn(),
+    find: vi.fn(),
+    findOne: vi.fn(),
+    delete: vi.fn()
+  };
+  const sapIntegration = {
+    integratePartner: vi.fn(),
+    retry: vi.fn(),
+    markSegmentsAsError: vi.fn()
+  };
+
+  let service: InstanceType<typeof PartnersService>;
+
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    draftRepo.create.mockReset();
+    draftRepo.save.mockReset();
+    draftRepo.find.mockReset();
+    draftRepo.findOne.mockReset();
+    draftRepo.delete.mockReset();
+
+    service = new PartnersService(
+      repo as any,
+      changeRepo as any,
+      auditJobRepo as any,
+      auditLogRepo as any,
+      noteRepo as any,
+      draftRepo as any,
+      sapIntegration as any
+    );
+  });
+
+  const user = { id: "user-1", email: "user@example.com", name: "User" } as const;
+
+  it("rejects draft creation without authenticated user", async () => {
+    await expect(service.createDraft({ payload: {} }, undefined as any)).rejects.toBeInstanceOf(UnauthorizedException);
+  });
+
+  it("creates a draft tied to the author", async () => {
+    draftRepo.create.mockImplementation((value) => ({ id: "draft-1", ...value }));
+    draftRepo.save.mockResolvedValue({ id: "draft-1", payload: { nome: "Teste" }, status: "draft", createdById: user.id });
+
+    const result = await service.createDraft({ payload: { nome: "Teste" } }, user);
+
+    expect(draftRepo.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: { nome: "Teste" },
+        createdById: user.id,
+        createdByName: user.name
+      })
+    );
+    expect(result).toMatchObject({ id: "draft-1", payload: { nome: "Teste" }, createdById: user.id });
+  });
+
+  it("lists only drafts of the current author", async () => {
+    draftRepo.find.mockResolvedValue([{ id: "draft-1" }, { id: "draft-2" }]);
+    const result = await service.listDrafts(user as any);
+    expect(draftRepo.find).toHaveBeenCalledWith({
+      where: { createdById: user.id },
+      order: { updatedAt: "DESC" }
+    });
+    expect(result).toHaveLength(2);
+  });
+
+  it("updates draft payload merging fields", async () => {
+    const draft = { id: "draft-1", payload: { nome: "Antigo", documento: "123" }, createdById: user.id };
+    draftRepo.findOne.mockResolvedValue(draft);
+    draftRepo.save.mockImplementation(async (value) => value);
+
+    const result = await service.updateDraft("draft-1", { payload: { nome: "Novo" } }, user as any);
+
+    expect(result.payload).toEqual({ nome: "Novo", documento: "123" });
+    expect(draftRepo.save).toHaveBeenCalledWith(expect.objectContaining({ id: "draft-1" }));
+  });
+
+  it("throws when updating draft from another user", async () => {
+    draftRepo.findOne.mockResolvedValue({ id: "draft-1", payload: {}, createdById: "other" });
+    await expect(service.updateDraft("draft-1", { payload: {} }, user as any)).rejects.toBeInstanceOf(ForbiddenException);
+  });
+
+  it("throws not found when draft is missing", async () => {
+    draftRepo.findOne.mockResolvedValue(null);
+    await expect(service.updateDraft("draft-unknown", { payload: {} }, user as any)).rejects.toBeInstanceOf(NotFoundException);
+  });
+
+  it("deletes draft after ownership validation", async () => {
+    draftRepo.findOne.mockResolvedValue({ id: "draft-1", payload: {}, createdById: user.id });
+    draftRepo.delete.mockResolvedValue({} as any);
+
+    const response = await service.deleteDraft("draft-1", user as any);
+    expect(draftRepo.delete).toHaveBeenCalledWith("draft-1");
+    expect(response).toEqual({ success: true });
+  });
+});

--- a/mdm-platform/apps/api/src/modules/partners/dto/partner-draft.dto.ts
+++ b/mdm-platform/apps/api/src/modules/partners/dto/partner-draft.dto.ts
@@ -1,0 +1,16 @@
+import { ApiPropertyOptional } from "@nestjs/swagger";
+import { IsObject, IsOptional } from "class-validator";
+
+export class CreatePartnerDraftDto {
+  @ApiPropertyOptional({ type: Object, description: "Dados parciais do formulário do parceiro" })
+  @IsOptional()
+  @IsObject()
+  payload?: Record<string, any>;
+}
+
+export class UpdatePartnerDraftDto {
+  @ApiPropertyOptional({ type: Object, description: "Campos a serem atualizados no rascunho" })
+  @IsOptional()
+  @IsObject()
+  payload?: Record<string, any>;
+}

--- a/mdm-platform/apps/api/src/modules/partners/entities/partner-draft.entity.ts
+++ b/mdm-platform/apps/api/src/modules/partners/entities/partner-draft.entity.ts
@@ -1,0 +1,26 @@
+import { Column, CreateDateColumn, Entity, Index, PrimaryGeneratedColumn, UpdateDateColumn } from "typeorm";
+
+@Entity("partner_drafts")
+@Index(["createdById"])
+export class PartnerDraft {
+  @PrimaryGeneratedColumn("uuid")
+  id!: string;
+
+  @Column({ type: "varchar", default: "draft" })
+  status!: "draft";
+
+  @Column("jsonb", { default: {} })
+  payload!: Record<string, any>;
+
+  @Column({ name: "created_by_id", type: "varchar" })
+  createdById!: string;
+
+  @Column({ name: "created_by_name", type: "varchar", nullable: true })
+  createdByName?: string | null;
+
+  @CreateDateColumn({ name: "created_at" })
+  createdAt!: Date;
+
+  @UpdateDateColumn({ name: "updated_at" })
+  updatedAt!: Date;
+}

--- a/mdm-platform/apps/api/src/modules/partners/partners.controller.ts
+++ b/mdm-platform/apps/api/src/modules/partners/partners.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Param, Post, Query, Req, UseGuards } from "@nestjs/common";
+import { Body, Controller, Delete, Get, Param, Patch, Post, Query, Req, UseGuards } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiParam, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { AuthGuard } from "@nestjs/passport";
 import { CreatePartnerDto } from "./dto/create-partner.dto";
@@ -6,6 +6,7 @@ import { ChangeRequestListQueryDto, CreateBulkChangeRequestDto, CreateChangeRequ
 import { AuthenticatedUser, PartnersService } from "./partners.service";
 import { SAP_INTEGRATION_SEGMENTS } from "./sap-integration.service";
 import { CreatePartnerNoteDto } from "./dto/partner-note.dto";
+import { CreatePartnerDraftDto, UpdatePartnerDraftDto } from "./dto/partner-draft.dto";
 
 class AuditRequestDto {
   partnerIds!: string[];
@@ -28,6 +29,26 @@ type AuthenticatedRequest = { user: AuthenticatedUser };
 @Controller("partners")
 export class PartnersController {
   constructor(private readonly svc: PartnersService) {}
+
+  @Post("drafts")
+  createDraft(@Body() dto: CreatePartnerDraftDto, @Req() req: AuthenticatedRequest) {
+    return this.svc.createDraft(dto, req.user);
+  }
+
+  @Get("drafts")
+  listDrafts(@Req() req: AuthenticatedRequest) {
+    return this.svc.listDrafts(req.user);
+  }
+
+  @Patch("drafts/:id")
+  updateDraft(@Param("id") id: string, @Body() dto: UpdatePartnerDraftDto, @Req() req: AuthenticatedRequest) {
+    return this.svc.updateDraft(id, dto, req.user);
+  }
+
+  @Delete("drafts/:id")
+  deleteDraft(@Param("id") id: string, @Req() req: AuthenticatedRequest) {
+    return this.svc.deleteDraft(id, req.user);
+  }
 
   @Post()
   create(@Body() dto: CreatePartnerDto) {

--- a/mdm-platform/apps/api/src/modules/partners/partners.module.ts
+++ b/mdm-platform/apps/api/src/modules/partners/partners.module.ts
@@ -10,10 +10,11 @@ import { AuthModule } from '../auth/auth.module';
 import { SapIntegrationService } from './sap-integration.service';
 import { SapSyncService } from './sap-sync.service';
 import { PartnerNote } from './entities/partner-note.entity';
+import { PartnerDraft } from './entities/partner-draft.entity';
 
 @Module({
   imports: [
-    TypeOrmModule.forFeature([Partner, PartnerChangeRequest, PartnerAuditJob, PartnerAuditLog, PartnerNote]),
+    TypeOrmModule.forFeature([Partner, PartnerChangeRequest, PartnerAuditJob, PartnerAuditLog, PartnerNote, PartnerDraft]),
     AuthModule,
   ],
   providers: [PartnersService, SapIntegrationService, SapSyncService],

--- a/mdm-platform/apps/web/src/app/(protected)/components/new-entity-menu.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/components/new-entity-menu.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useMemo, useRef, useState } from "react";
+import React, { useEffect, useMemo, useRef, useState } from "react";
 import { useRouter } from "next/navigation";
 import { ChevronDown, Plus } from "lucide-react";
 

--- a/mdm-platform/apps/web/src/app/(protected)/dashboard/__tests__/page.spec.tsx
+++ b/mdm-platform/apps/web/src/app/(protected)/dashboard/__tests__/page.spec.tsx
@@ -1,0 +1,92 @@
+import React from "react";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import axios from "axios";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import Dashboard from "../page";
+
+vi.mock("axios", () => ({
+  default: {
+    get: vi.fn(),
+    post: vi.fn(),
+    put: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn()
+  }
+}));
+
+const routerPushMock = vi.fn();
+const routerReplaceMock = vi.fn();
+const routerMock = {
+  push: routerPushMock,
+  replace: routerReplaceMock
+};
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => routerMock
+}));
+
+type AxiosMock = {
+  get: ReturnType<typeof vi.fn>;
+  post: ReturnType<typeof vi.fn>;
+  put: ReturnType<typeof vi.fn>;
+  patch: ReturnType<typeof vi.fn>;
+  delete: ReturnType<typeof vi.fn>;
+};
+
+const axiosMock = axios as unknown as AxiosMock;
+
+describe("Dashboard drafts section", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    axiosMock.get.mockReset();
+    axiosMock.delete.mockReset();
+    routerPushMock.mockReset();
+    routerReplaceMock.mockReset();
+    localStorage.clear();
+    localStorage.setItem("mdmToken", "token");
+    process.env.NEXT_PUBLIC_API_URL = "http://localhost:3333";
+  });
+
+  it("lists drafts with resume and delete actions", async () => {
+    axiosMock.get.mockImplementation((url: string) => {
+      if (url === "http://localhost:3333/partners") {
+        return Promise.resolve({ data: [] });
+      }
+      if (url === "http://localhost:3333/partners/drafts") {
+        return Promise.resolve({
+          data: [
+            {
+              id: "draft-1",
+              payload: { nome_legal: "Empresa X", natureza: "cliente" },
+              updatedAt: "2024-05-10T12:00:00.000Z"
+            }
+          ]
+        });
+      }
+      return Promise.resolve({ data: [] });
+    });
+    axiosMock.delete.mockResolvedValue({});
+
+    render(<Dashboard />);
+
+    await waitFor(() => {
+      expect(axiosMock.get.mock.calls.length).toBeGreaterThanOrEqual(2);
+    });
+
+    expect(screen.getByText(/meus rascunhos/i)).toBeInTheDocument();
+    expect(screen.getByText(/empresa x/i)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByRole("button", { name: /retomar/i }));
+    expect(routerPushMock).toHaveBeenCalledWith("/partners/new?draftId=draft-1");
+
+    await userEvent.click(screen.getByRole("button", { name: /excluir rascunho/i }));
+    await waitFor(() => {
+      expect(axiosMock.delete).toHaveBeenCalledWith(
+        "http://localhost:3333/partners/drafts/draft-1",
+        expect.objectContaining({ headers: { Authorization: "Bearer token" } })
+      );
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add draft DTOs, entity, service methods, and routes for partner drafts with dedicated tests
- enable the new partner flow to save/load drafts and persist draft metadata across sessions
- surface user draft listings on the dashboard with resume/delete actions and supporting UI tests

## Testing
- pnpm vitest run apps/api/src/modules/partners/__tests__/drafts.spec.ts --run
- pnpm vitest run 'apps/web/src/app/(protected)/partners/new/__tests__/page.spec.tsx' --run
- pnpm vitest run 'apps/web/src/app/(protected)/dashboard/__tests__/page.spec.tsx' --run

------
https://chatgpt.com/codex/tasks/task_e_68e2d9b35900832587a83f1049364a0b